### PR TITLE
Explicitize implicits

### DIFF
--- a/src/Base/Bool.path
+++ b/src/Base/Bool.path
@@ -15,4 +15,4 @@ not : Bool -> Bool
 not = \ f a b . f b a
 
 (if _ then _ else _) : { a : Type } -> Bool -> Lazy a -> Lazy a -> a
-(if _ then _ else _) = \ c t e . force (c t e)
+(if _ then _ else _) = \ {a} c t e . force {a} (c {Lazy a} t e)

--- a/src/Base/Either.path
+++ b/src/Base/Either.path
@@ -3,18 +3,25 @@ module Base.Either
 Either : Type -> Type -> Type
 Either = \ l r . { a : Type } -> (l -> a) -> (r -> a) -> a
 
-left : l -> Either l r
-left = \ l left _ . left l
+left : { l : Type } -> { r : Type } -> l -> Either l r
+left = \ {_} {_} l {_} left _ . left l
 
-right : r -> Either l r
-right = \ r _ right . right r
+right : { l : Type } -> { r : Type } -> r -> Either l r
+right = \ {_} {_} r {_} _ right . right r
 
 
-map :  (r -> r')
+map :  { l : Type }
+    -> { r : Type }
+    -> { r' : Type }
+    -> (r -> r')
     -> (Either l r -> Either l r')
-map = \ f e . e left (\ r . right (f r))
+map = \ {l} {_} {r'} f e . e {Either l r'} (left {l} {r'}) (\ r . right {l} {r'} (f r))
 
-bimap :  (       l   ->        l')
+bimap :  { l : Type }
+      -> { r : Type }
+      -> { l' : Type }
+      -> { r' : Type }
+      -> (       l   ->        l')
       -> (         r ->           r')
       -> (Either l r -> Either l' r')
-bimap = \ f g e . e (\ l . left (f l)) (\ r . right (g r))
+bimap = \ {_} {_} {l'} {r'} f g e . e {Either l' r'} (\ l . left {l'} {r'} (f l)) (\ r . right {l'} {r'} (g r))

--- a/src/Base/Fix.path
+++ b/src/Base/Fix.path
@@ -7,9 +7,10 @@ Fix : (Type -> Type) -> Type
 Fix = \ f . { x : Type } -> Alg f x -> x
 
 fold :  { f : Type -> Type }
+     -> { x : Type }
      -> Alg f x -> Fix f -> x
-fold = \ alg x . x alg
+fold = \ {_} {x} alg term . term {x} alg
 
 in :  { f : Type -> Type }
    -> f (Fix f) -> Fix f
-in = \ fix alg . alg (fold alg) fix
+in = \ {f} syn {x} alg . alg {Fix f} (fold {f} {x} alg) syn

--- a/src/Base/Function.path
+++ b/src/Base/Function.path
@@ -1,19 +1,24 @@
 module Base.Function
 
-id : a -> a
-id = \ a . a
+id : { a : Type } -> a -> a
+id = \ {_} a . a
 
-const : a -> b -> a
-const = \ a _ . a
+const : { a : Type } -> { b : Type } -> a -> b -> a
+const = \ {_} {_} a _ . a
 
-flip : (a -> b -> c) -> (b -> a -> c)
-flip = \ f b a . f a b
+flip : { a : Type } -> { b : Type } -> { c : Type } -> (a -> b -> c) -> (b -> a -> c)
+flip = \ {_} {_} {_} f b a . f a b
 
-fix :  ((a -> b) -> a -> b)
+fix :  { a : Type }
+    -> { b : Type }
+    -> ((a -> b) -> a -> b)
     -> (a -> b)
-fix = \ f . f (fix f)
+fix = \ {a} {b} f . f (fix {a} {b} f)
 
-compose :  (b -> c)
+compose :  { a : Type }
+        -> { b : Type }
+        -> { c : Type }
+        -> (b -> c)
         -> (a -> b)
         -> (a -> c)
-compose = \ f g x . f (g x)
+compose = \ {_} {_} {_} f g x . f (g x)

--- a/src/Base/Lazy.path
+++ b/src/Base/Lazy.path
@@ -5,5 +5,5 @@ import Base.Unit
 Lazy : Type -> Type
 Lazy = \ a . Unit -> a
 
-force : Lazy a -> a
-force = \ f . f unit
+force : { a : Type } -> Lazy a -> a
+force = \ {_} f . f unit

--- a/src/Base/List.path
+++ b/src/Base/List.path
@@ -5,27 +5,29 @@ import Base.Fix
 ListF : Type -> Type -> Type
 ListF = \ a b . { c : Type } -> c -> (a -> b -> c) -> c
 
-nilf : ListF a b
-nilf = \ nil _ . nil
+nilf : { a : Type } -> { b : Type } -> ListF a b
+nilf = \ {_} {_} {_} nil _ . nil
 
-consf : a -> b -> ListF a b
-consf = \ a b _ cons . cons a b
+consf : { a : Type } -> { b : Type } -> a -> b -> ListF a b
+consf = \ {_} {_} a b {_} _ cons . cons a b
 
 
 List : Type -> Type
 List = \ a . Fix (ListF a)
 
-nil : List a
-nil = in nilf
+nil : { a : Type } -> List a
+nil = \ {a} . in {ListF a} (nilf {a} {List a})
 
-cons : a -> List a -> List a
-cons = \ h t . in (consf h t)
-
-
-append : List a -> List a -> List a
-append = \ xs ys . xs (\ k f . f ys (\ x xs . cons x (k xs)))
+cons : { a : Type } -> a -> List a -> List a
+cons = \ {a} h t . in {ListF a} (consf {a} h {List a} t)
 
 
-map :  (a -> b)
+append : { a : Type } -> List a -> List a -> List a
+append = \ {a} xs ys . xs {List a} (\ k f . f ys (\ x xs . cons {a} x (k xs)))
+
+
+map :  { a : Type }
+    -> { b : Type }
+    -> (a -> b)
     -> (List a -> List b)
-map = \ f l . l (\ k g . g nil (\ a as . cons (f a) (k as)))
+map = \ {_} {b} f l . l {List b} (\ k g . g (nil {b}) (\ a as . cons {b} (f a) (k as)))

--- a/src/Base/Maybe.path
+++ b/src/Base/Maybe.path
@@ -6,15 +6,17 @@ import Base.Function
 Maybe : Type -> Type
 Maybe = \ a . { b : Type } -> b -> (a -> b) -> b
 
-just : a -> Maybe a
-just = \ a _ just . just a
+just : { a : Type } -> a -> Maybe a
+just = \ {_} a {_} _ just . just a
 
-nothing : Maybe a
-nothing = \ nothing _ . nothing
+nothing : { a : Type } -> Maybe a
+nothing = \ {_} {_} nothing _ . nothing
 
-isJust : Maybe a -> Bool
-isJust = \ m . m false (\ _ . true)
+isJust : { a : Type } -> Maybe a -> Bool
+isJust = \ {_} m . m {Bool} false (\ _ . true)
 
-map :  (a -> b)
+map :  { a : Type }
+    -> { b : Type }
+    -> (a -> b)
     -> (Maybe a -> Maybe b)
-map = \ f m . m nothing (\ a . just (f a))
+map = \ {_} {b} f m . m {Maybe b} (nothing {b}) (\ a . just {b} (f a))

--- a/src/Base/Nat.path
+++ b/src/Base/Nat.path
@@ -5,29 +5,29 @@ import Base.Fix
 NatF : Type -> Type
 NatF = \ a . { b : Type } -> b -> (a -> b) -> b
 
-zf : NatF a
-zf = \ z _ . z
+zf : { a : Type } -> NatF a
+zf = \ {_} {_} z _ . z
 
-sf : a -> NatF a
-sf = \ a _ s . s a
+sf : { a : Type } -> a -> NatF a
+sf = \ {_} a {_} _ s . s a
 
 
 Nat : Type
 Nat = Fix NatF
 
 z : Nat
-z = in zf
+z = in {NatF} (zf {Nat})
 
 s : Nat -> Nat
-s = \ n . in (sf n)
+s = \ n . in {NatF} (sf {Nat} n)
 
 
 iter : { a : Type } -> a -> (a -> a) -> Nat -> a
-iter = \ z s n . n (\ k f . f z (\ m . s (k m)))
+iter = \ {a} z s n . n {a} (\ k f . f z (\ m . s (k m)))
 
 
 (_ + _) : Nat -> Nat -> Nat
-(_ + _) = \ m . iter m s
+(_ + _) = \ m . iter {Nat} m s
 
 (_ * _) : Nat -> Nat -> Nat
-(_ * _) = \ m . iter z ((_ + _) m)
+(_ * _) = \ m . iter {Nat} z ((_ + _) m)

--- a/src/Base/Pair.path
+++ b/src/Base/Pair.path
@@ -3,21 +3,28 @@ module Base.Pair
 Pair : Type -> Type -> Type
 Pair = \ l r . { a : Type } -> (l -> r -> a) -> a
 
-pair : l -> r -> Pair l r
-pair = \ l r f . f l r
+pair : { l : Type } -> { r : Type } -> l -> r -> Pair l r
+pair = \ {_} {_} l r {_} f . f l r
 
-fst : Pair l r -> l
-fst = \ p . p (\ fst _ . fst)
+fst : { l : Type } -> { r : Type } -> Pair l r -> l
+fst = \ {l} {_} p . p {l} (\ fst _ . fst)
 
-snd : Pair l r -> r
-snd = \ p . p (\ _ snd . snd)
+snd : { l : Type } -> { r : Type } -> Pair l r -> r
+snd = \ {_} {r} p . p {r} (\ _ snd . snd)
 
 
-map :  (r -> r')
+map :  { l : Type }
+    -> { r : Type }
+    -> { r' : Type }
+    -> (r -> r')
     -> (Pair l r -> Pair l r')
-map = \ f e . e (\ l' r . pair l' (f r))
+map = \ {l} {_} {r'} f e . e {Pair l r'} (\ l' r . pair {l} {r'} l' (f r))
 
-bimap :  (     l   ->      l')
+bimap :  { l : Type }
+      -> { r : Type }
+      -> { l' : Type }
+      -> { r' : Type }
+      -> (     l   ->      l')
       -> (       r ->         r')
       -> (Pair l r -> Pair l' r')
-bimap = \ f g e . e (\ l r . pair (f l) (g r))
+bimap = \ {_} {_} {l'} {r'} f g e . e {Pair l' r'} (\ l r . pair {l'} {r'} (f l) (g r))

--- a/src/Base/Sigma.path
+++ b/src/Base/Sigma.path
@@ -4,7 +4,7 @@ Sigma : (A : Type) -> (A -> Type) -> Type
 Sigma = \ A B . { C : Type } -> (( a : A ) -> B a -> C) -> C
 
 sigma :  { A : Type } -> { B : A -> Type } -> ( a : A ) -> B a -> Sigma A B
-sigma = \ a b f . f a b
+sigma = \ {_} {_} a b {_} f . f a b
 
 fst : { A : Type } -> { B : A -> Type } -> Sigma A B -> A
-fst = \ s . s (\ a _ . a)
+fst = \ {A} {_} s . s {A} (\ a _ . a)

--- a/src/Base/Vector.path
+++ b/src/Base/Vector.path
@@ -9,8 +9,8 @@ Vector = \ n a
   -> ({ n : Nat } -> a -> x n -> x (s n))
   -> x n
 
-nil : Vector z a
-nil = \ nil _ . nil
+nil : { a : Type } -> Vector z a
+nil = \ {_} nil _ . nil
 
-cons : { n : Nat } -> a -> Vector n a -> Vector (s n) a
-cons = \ h t nil cons . cons h (t nil cons)
+cons : { n : Nat } -> { a : Type } -> a -> Vector n a -> Vector (s n) a
+cons = \ {_} {_} h t {x} nil cons . cons h (t {x} nil cons)

--- a/src/Path/Constraint.hs
+++ b/src/Path/Constraint.hs
@@ -31,6 +31,9 @@ instance FreeVariables v a => FreeVariables v (Equation a) where
 newtype Substitution = Substitution { unSubstitution :: Map.Map Gensym (Value Meta) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
+newtype Signature = Signature { unSignature :: Map.Map Gensym (Value Meta) }
+  deriving (Eq, Monoid, Ord, Semigroup, Show)
+
 class Substitutable t where
   apply :: Substitution -> t -> t
 

--- a/src/Path/Constraint.hs
+++ b/src/Path/Constraint.hs
@@ -34,6 +34,12 @@ newtype Substitution = Substitution { unSubstitution :: Map.Map Gensym (Value Me
 newtype Signature = Signature { unSignature :: Map.Map Gensym (Value Meta) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
+instance Pretty Signature where
+  pretty (Signature sig)
+    | null sig  = mempty
+    | otherwise = encloseSep (magenta (pretty "Σ") <> space) mempty (cyan comma <> space) (map (uncurry prettyBind) (Map.toList sig)) <> hardline
+    where prettyBind m t = pretty (Meta m) <+> cyan colon <+> pretty t
+
 class Substitutable t where
   apply :: Substitution -> t -> t
 

--- a/src/Path/Constraint.hs
+++ b/src/Path/Constraint.hs
@@ -107,13 +107,13 @@ instance Pretty (Constraint Meta) where
   pretty c = group . run . runNaming (Root "pretty") $ do
     (Context ctx, (v1 :===: v2) ::: t) <- unbinds c
     binds <- traverse prettyBind ctx
-    v1' <- prettyValue qlocal v1
-    v2' <- prettyValue qlocal v2
-    t'  <- prettyValue qlocal t
+    v1' <- prettyValue Name v1
+    v2' <- prettyValue Name v2
+    t'  <- prettyValue Name t
     pure (cat (zipWith (<>) (l : repeat s) (toList binds) <> map (flatAlt mempty space <>) [ magenta (pretty "⊢") <+> prettyPrec 0 v1', magenta (pretty "≡") <+> prettyPrec 0 v2', cyan colon <+> prettyPrec 0 t' ]))
     where l = magenta (pretty "Γ") <> space
           s = softbreak <> cyan comma <> space
-          prettyBind (n ::: t) = pretty . (qlocal n :::) . prettyPrec 0 <$> prettyValue qlocal t
+          prettyBind (n ::: t) = pretty . (Name n :::) . prettyPrec 0 <$> prettyValue Name t
 
 
 infixr 1 |-
@@ -122,11 +122,11 @@ infixr 1 |-
 n ::: t |- b = t :|-: bind n b
 
 binds :: Context (Type Meta) -> Equation (Value Meta) ::: Type Meta -> Constraint Meta
-binds (Context names) body = foldr (|-) (E body) (first qlocal <$> names)
+binds (Context names) body = foldr (|-) (E body) (first Name <$> names)
 
 unbinds :: (Carrier sig m, Member Naming sig) => Constraint Meta -> m (Context (Type Meta), Equation (Value Meta) ::: Type Meta)
 unbinds = fmap (first Context) . un (\ name -> \case
-  t :|-: b -> Right (name ::: t, instantiate (pure (qlocal name)) b)
+  t :|-: b -> Right (name ::: t, instantiate (pure (Name name)) b)
   E q      -> Left q)
 
 

--- a/src/Path/Constraint.hs
+++ b/src/Path/Constraint.hs
@@ -31,6 +31,12 @@ instance FreeVariables v a => FreeVariables v (Equation a) where
 newtype Substitution = Substitution { unSubstitution :: Map.Map Gensym (Value Meta) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
+instance Pretty Substitution where
+  pretty (Substitution sig)
+    | null sig  = mempty
+    | otherwise = encloseSep (magenta (pretty "Θ") <> space) mempty (cyan comma <> space) (map (uncurry prettyBind) (Map.toList sig)) <> hardline
+    where prettyBind m t = pretty (Meta m) <+> cyan (pretty "=") <+> pretty t
+
 newtype Signature = Signature { unSignature :: Map.Map Gensym (Value Meta) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -29,10 +29,6 @@ instance Applicative Core where
 instance Monad Core where
   a >>= f = joinT (fmap f a)
 
-name :: Name -> Core Gensym
-name (Local  n) = Var n
-name (Global n) = Glo n
-
 lam :: Eq a => Plicit a -> Core a -> Core a
 lam (p :< n) b = Lam (p :< Nothing) (bind n b)
 

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -29,6 +29,10 @@ instance Applicative Core where
 instance Monad Core where
   a >>= f = joinT (fmap f a)
 
+name :: Name -> Core Name
+name (Local  n) = Var (Local n)
+name (Global n) = Glo n
+
 lam :: Eq a => Plicit a -> Core a -> Core a
 lam (p :< n) b = Lam (p :< Nothing) (bind n b)
 

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -10,6 +10,7 @@ import Text.Trifecta.Rendering (Span)
 
 data Core a
   = Var a
+  | Glo Qualified
   | Lam (Plicit (Maybe User)) (Scope a)
   | Core a :$ Plicit (Core a)
   | Type
@@ -37,6 +38,7 @@ lams names body = foldr lam body names
 
 gfoldT :: forall m n b
        .  (forall a . m a -> n a)
+       -> (forall a . Qualified -> n a)
        -> (forall a . Plicit (Maybe User) -> n (Incr a) -> n a)
        -> (forall a . n a -> Plicit (n a) -> n a)
        -> (forall a . n a)
@@ -46,10 +48,11 @@ gfoldT :: forall m n b
        -> (forall a . Incr (m a) -> m (Incr a))
        -> Core (m b)
        -> n b
-gfoldT var lam app ty pi hole ann dist = go
+gfoldT var glo lam app ty pi hole ann dist = go
   where go :: Core (m x) -> n x
         go = \case
           Var a -> var a
+          Glo a -> glo a
           Lam n (Scope b) -> lam n (go (dist <$> b))
           f :$ a -> app (go f) (go <$> a)
           Type -> ty
@@ -58,7 +61,7 @@ gfoldT var lam app ty pi hole ann dist = go
           Ann span a -> ann span (go a)
 
 joinT :: Core (Core a) -> Core a
-joinT = gfoldT id (\ n -> Lam n . Scope) (:$) Type (\ p -> Pi p . Scope) Hole Ann (incr (pure Z) (fmap S))
+joinT = gfoldT id Glo (\ n -> Lam n . Scope) (:$) Type (\ p -> Pi p . Scope) Hole Ann (incr (pure Z) (fmap S))
 
 
 -- | Substitute occurrences of a variable with a 'Core' within another 'Core'.

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -14,7 +14,7 @@ data Core a
   | Core a :$ Plicit (Core a)
   | Type
   | Pi (Plicit (Maybe User, Usage, Core a)) (Scope a)
-  | Hole a
+  | Hole Gensym
   | Ann Span (Core a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
@@ -41,7 +41,7 @@ gfoldT :: forall m n b
        -> (forall a . n a -> Plicit (n a) -> n a)
        -> (forall a . n a)
        -> (forall a . Plicit (Maybe User, Usage, n a) -> n (Incr a) -> n a)
-       -> (forall a . m a -> n a)
+       -> (forall a . Gensym -> n a)
        -> (forall a . Span -> n a -> n a)
        -> (forall a . Incr (m a) -> m (Incr a))
        -> Core (m b)
@@ -58,7 +58,7 @@ gfoldT var lam app ty pi hole ann dist = go
           Ann span a -> ann span (go a)
 
 joinT :: Core (Core a) -> Core a
-joinT = gfoldT id (\ n -> Lam n . Scope) (:$) Type (\ p -> Pi p . Scope) id Ann (incr (pure Z) (fmap S))
+joinT = gfoldT id (\ n -> Lam n . Scope) (:$) Type (\ p -> Pi p . Scope) Hole Ann (incr (pure Z) (fmap S))
 
 
 -- | Substitute occurrences of a variable with a 'Core' within another 'Core'.

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -29,8 +29,8 @@ instance Applicative Core where
 instance Monad Core where
   a >>= f = joinT (fmap f a)
 
-name :: Name -> Core Name
-name (Local  n) = Var (Local n)
+name :: Name -> Core Gensym
+name (Local  n) = Var n
 name (Global n) = Glo n
 
 lam :: Eq a => Plicit a -> Core a -> Core a

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -148,8 +148,6 @@ instance Effect Elab where
 runElab :: ElabC m a -> m (Set.Set (Spanned (Constraint Meta)), a)
 runElab = runWriter . runReader mempty . runElabC
 
-type Signature = Map.Map Gensym (Value Meta)
-
 newtype ElabC m a = ElabC { runElabC :: ReaderC (Context (Type Meta)) (WriterC (Set.Set (Spanned (Constraint Meta))) m) a }
   deriving (Applicative, Functor, Monad)
 

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -114,6 +114,7 @@ elab :: (Carrier sig m, Member Elab sig, Member Naming sig, Member (Reader Span)
      -> m (Value Meta ::: Type Meta)
 elab = \case
   Core.Var n -> assume n
+  Core.Glo n -> assume (Global n)
   Core.Lam n b -> intro n (\ n' -> elab (Core.instantiate (pure n') b))
   f Core.:$ (p :< a) -> app (elab f) (p :< elab a)
   Core.Type -> pure (Type ::: Type)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -119,9 +119,7 @@ elab = \case
   f Core.:$ (p :< a) -> app (elab f) (p :< elab a)
   Core.Type -> pure (Type ::: Type)
   Core.Pi (p :< (n, m, t)) b -> pi (p :< (n, m, elab t)) (\ n' -> elab (Core.instantiate (pure n') b))
-  Core.Hole _ -> do
-    ty <- exists Type
-    (::: ty) <$> exists ty
+  Core.Hole h -> (pure (Meta h) :::) <$> exists Type
   Core.Ann ann b -> spanIs ann (elab b)
 
 

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -42,7 +42,7 @@ assume v = do
 
 implicits :: (Carrier sig m, Member Elab sig) => Type Meta -> m (Stack (Plicit (m (Value Meta ::: Type Meta))))
 implicits = go Nil
-  where go names (Value.Pi (Im :< (_, t)) b) = do
+  where go names (Value.Pi (Im :< (_, t)) b) | False = do
           v <- exists t
           go (names :> (Im :< pure (v ::: t))) (Value.instantiate v b)
         go names _ = pure names
@@ -229,7 +229,7 @@ elabDecl (decl :~ span) = namespace (show (declName decl)) . runReader span . fm
         scope <- get
         let ty' = whnf scope ty
         (names, _) <- un (orTerm (\ n -> \case
-          Value.Pi (Im :< _) b -> Just (Im :< Local n, whnf scope (Value.instantiate (pure (Local n)) b))
+          Value.Pi (Im :< _) b | False -> Just (Im :< Local n, whnf scope (Value.instantiate (pure (Local n)) b))
           _                    -> Nothing)) ty'
         pure (Core.lams names tm ::: Value.weaken ty)
       Nothing -> (tm :::) <$> inferType

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -155,7 +155,9 @@ instance (Carrier sig m, Effect sig, Member Naming sig, Member (Reader Scope) si
   eff (L (Exists ty k)) = do
     ctx <- ElabC ask
     n <- gensym "meta"
-    modify (Signature . Map.insert n ty . unSignature)
+    let f (n ::: t) = Ex :< (qlocal n, More) ::: t
+        ty' = Value.pis (f <$> Context.unContext ctx) ty
+    modify (Signature . Map.insert n ty' . unSignature)
     k (pure (Meta n) Value.$$* ((Ex :<) . pure . qlocal <$> Context.vars (ctx :: Context (Type Meta))))
   eff (L (Have n k)) = lookup n >>= maybe missing pure >>= k
     where lookup (Global n) = ElabC (asks (Scope.lookup   n)) >>= pure . fmap (Value.weaken . entryType)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -113,8 +113,7 @@ elab :: (Carrier sig m, Member Elab sig, Member Naming sig, Member (Reader Span)
      => Core.Core Gensym
      -> m (Value Meta ::: Type Meta)
 elab = \case
-  Core.Var n -> assume (Local n)
-  Core.Glo n -> assume (Global n)
+  Core.Var n -> assume n
   Core.Lam n b -> intro n (\ n' -> elab (Core.instantiate (pure n') b))
   f Core.:$ (p :< a) -> app (elab f) (p :< elab a)
   Core.Type -> pure (Type ::: Type)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -155,7 +155,7 @@ instance (Carrier sig m, Effect sig, Member Naming sig, Member (Reader Scope) si
   eff (L (Exists ty k)) = do
     ctx <- ElabC ask
     n <- gensym "meta"
-    modify (Map.insert n ty)
+    modify (Signature . Map.insert n ty . unSignature)
     k (pure (Meta n) Value.$$* ((Ex :<) . pure . qlocal <$> Context.vars (ctx :: Context (Type Meta))))
   eff (L (Have n k)) = lookup n >>= maybe missing pure >>= k
     where lookup (Global n) = ElabC (asks (Scope.lookup   n)) >>= pure . fmap (Value.weaken . entryType)

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -25,8 +25,9 @@ ambiguousName name sources = do
     : map prettyQName (toList sources)))])
 
 
-unsimplifiableConstraint :: (Carrier sig m, Member (Error Doc) sig) => Spanned (Constraint Meta) -> m a
-unsimplifiableConstraint (c :~ span) = throwError (prettyErr span (pretty "unsimplifiable constraint") [pretty c])
+unsimplifiableConstraint :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
+unsimplifiableConstraint constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
+  where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]
 
 stalledConstraints :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
 stalledConstraints constraints = throwError (fold (intersperse hardline (map stalled constraints)))

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -28,7 +28,3 @@ ambiguousName name sources = do
 unsimplifiableConstraint :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
 unsimplifiableConstraint constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
   where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]
-
-stalledConstraints :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
-stalledConstraints constraints = throwError (fold (intersperse hardline (map stalled constraints)))
-  where stalled (c :~ span) = prettyErr span (pretty "stalled constraint") [pretty c]

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -26,5 +26,5 @@ ambiguousName name sources = do
 
 
 unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => Signature -> [Spanned (Constraint Meta)] -> m a
-unsimplifiableConstraints _ constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
+unsimplifiableConstraints sig constraints = throwError (pretty sig <> fold (intersperse hardline (map unsimplifiable constraints)))
   where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -8,6 +8,7 @@ import Data.Foldable (fold, toList)
 import Data.List (intersperse)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Path.Constraint
 import Path.Name
 import Path.Pretty
@@ -29,8 +30,9 @@ ambiguousName name sources = do
 
 unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => Signature -> Substitution -> [Spanned (Constraint Meta)] -> m a
 unsimplifiableConstraints sig subst constraints = throwError (metas <> fold (intersperse hardline (map unsimplifiable constraints)))
-  where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]
+  where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty (sigFor c) <> pretty c]
         metas = encloseSep (magenta (pretty "Θ") <> space) mempty (cyan comma <> space) (map (uncurry prettyBind) (Map.toList entries)) <> if Prelude.null entries then mempty else hardline
         entries = foldr (uncurry define) (Entry . (Nothing :::) <$> unSignature sig) (Map.toList (unSubstitution subst))
         prettyBind m t = pretty (Meta m) <+> pretty t
         define m v = Map.update (\ e -> Just (Entry (Just v ::: entryType e))) m
+        sigFor c = let fvs' = metaNames (fvs c) in Signature (Map.filterWithKey (\ k _ -> k `Set.member` fvs') (unSignature sig))

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -25,6 +25,6 @@ ambiguousName name sources = do
     : map prettyQName (toList sources)))])
 
 
-unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => Signature -> [Spanned (Constraint Meta)] -> m a
-unsimplifiableConstraints sig constraints = throwError (pretty sig <> fold (intersperse hardline (map unsimplifiable constraints)))
+unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => Signature -> Substitution -> [Spanned (Constraint Meta)] -> m a
+unsimplifiableConstraints sig subst constraints = throwError (pretty sig <> pretty subst <> fold (intersperse hardline (map unsimplifiable constraints)))
   where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -19,7 +19,7 @@ freeVariable name = do
   span <- ask
   throwError (prettyErr span (pretty "free variable" <+> squotes (pretty name)) [])
 
-ambiguousName :: (Carrier sig m, Member (Error Doc) sig, Member (Reader Span) sig) => User -> NonEmpty Name -> m a
+ambiguousName :: (Carrier sig m, Member (Error Doc) sig, Member (Reader Span) sig) => User -> NonEmpty (Name Gensym) -> m a
 ambiguousName name sources = do
   span <- ask
   throwError (prettyErr span (pretty "ambiguous name" <+> squotes (pretty name)) [nest 2 (vsep

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -25,6 +25,6 @@ ambiguousName name sources = do
     : map prettyQName (toList sources)))])
 
 
-unsimplifiableConstraint :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
-unsimplifiableConstraint constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
+unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
+unsimplifiableConstraints constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
   where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -25,6 +25,6 @@ ambiguousName name sources = do
     : map prettyQName (toList sources)))])
 
 
-unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => [Spanned (Constraint Meta)] -> m a
-unsimplifiableConstraints constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
+unsimplifiableConstraints :: (Carrier sig m, Member (Error Doc) sig) => Signature -> [Spanned (Constraint Meta)] -> m a
+unsimplifiableConstraints _ constraints = throwError (fold (intersperse hardline (map unsimplifiable constraints)))
   where unsimplifiable (c :~ span) = prettyErr span (pretty "unsimplifiable constraint") [pretty c]

--- a/src/Path/Eval.hs
+++ b/src/Path/Eval.hs
@@ -8,6 +8,6 @@ import Path.Value as Value hiding (Scope(..))
 -- | Evaluate a 'Value' to weak head normal form.
 --
 --   This involves looking up variables at the head of neutral terms in the environment, but will leave other values alone, as they’re already constructor-headed.
-whnf :: Scope -> Value (Name Gensym) -> Value (Name Gensym)
+whnf :: Scope -> Value Gensym -> Value Gensym
 whnf scope (Global n :$ sp) = maybe (Global n :$ sp) (whnf scope . ($$* sp)) (Scope.lookup n scope >>= Scope.entryValue)
 whnf _     v                = v

--- a/src/Path/Eval.hs
+++ b/src/Path/Eval.hs
@@ -8,6 +8,6 @@ import Path.Value as Value hiding (Scope(..))
 -- | Evaluate a 'Value' to weak head normal form.
 --
 --   This involves looking up variables at the head of neutral terms in the environment, but will leave other values alone, as they’re already constructor-headed.
-whnf :: Scope -> Value Name -> Value Name
+whnf :: Scope -> Value (Name Gensym) -> Value (Name Gensym)
 whnf scope (Global n :$ sp) = maybe (Global n :$ sp) (whnf scope . ($$* sp)) (Scope.lookup n scope >>= Scope.entryValue)
 whnf _     v                = v

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -139,6 +139,10 @@ instance Pretty Name where
     Global (_ :.: n) -> pretty n
     Local         n  -> pretty '_' <> prettyGensym n
 
+name :: (Gensym -> a) -> (Qualified -> a) -> Name -> a
+name local _      (Local  n) = local n
+name _     global (Global n) = global n
+
 inModule :: ModuleName -> Name -> Bool
 inModule m (Global (m' :.: _)) = m == m'
 inModule _ _                   = False

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -129,32 +129,32 @@ instance Pretty Qualified where
   pretty (m :.: n) = pretty m <> dot <> pretty n
 
 
-data Name
+data Name a
   = Global Qualified
-  | Local Gensym
-  deriving (Eq, Ord, Show)
+  | Local a
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-instance Pretty Name where
+instance Pretty a => Pretty (Name a) where
   pretty = \case
     Global (_ :.: n) -> pretty n
-    Local         n  -> pretty '_' <> prettyGensym n
+    Local         n  -> pretty '_' <> pretty n
 
-name :: (Gensym -> a) -> (Qualified -> a) -> Name -> a
+name :: (a -> b) -> (Qualified -> b) -> Name a -> b
 name local _      (Local  n) = local n
 name _     global (Global n) = global n
 
-inModule :: ModuleName -> Name -> Bool
+inModule :: ModuleName -> Name Gensym -> Bool
 inModule m (Global (m' :.: _)) = m == m'
 inModule _ _                   = False
 
-prettyQName :: Name -> Doc
+prettyQName :: Name Gensym -> Doc
 prettyQName = \case
   Global n -> pretty n
   Local  n -> pretty '_' <> prettyGensym n
 
 
 data Meta
-  = Name Name
+  = Name (Name Gensym)
   | Meta Gensym
   deriving (Eq, Ord, Show)
 

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -154,7 +154,7 @@ prettyQName = \case
 
 
 data Meta
-  = Name (Name Gensym)
+  = Name Gensym
   | Meta Gensym
   deriving (Eq, Ord, Show)
 
@@ -163,11 +163,8 @@ instance Pretty Meta where
     Name q -> pretty q
     Meta m -> dullblack (bold (pretty '?' <> pretty m))
 
-qlocal :: Gensym -> Meta
-qlocal = Name . Local
-
 localNames :: Set.Set Meta -> Set.Set Gensym
-localNames = foldMap (\case { Name (Local v) -> Set.singleton v ; _ -> mempty })
+localNames = foldMap (\case { Name v -> Set.singleton v ; _ -> mempty })
 
 metaNames :: Set.Set Meta -> Set.Set Gensym
 metaNames = foldMap (\case { Meta m -> Set.singleton m ; _ -> mempty })

--- a/src/Path/Parser/Module.hs
+++ b/src/Path/Parser/Module.hs
@@ -5,7 +5,7 @@ import Control.Applicative ((<**>), Alternative(..))
 import Control.Effect
 import Control.Monad.IO.Class
 import qualified Path.Module as Module
-import Path.Name
+import Path.Name hiding (name)
 import Path.Parser
 import Path.Parser.Term
 import Path.Pretty (Doc)

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -16,8 +16,8 @@ type', var, hole, term, application, piType, functionType, lambda, atom :: Delta
 
 term = functionType
 
-application = foldl app <$> atom <*> many (plicit term atom) <?> "function application"
-  where app f@(_ :~ s1) a@(_ :< (_ :~ s2)) = (f :$ a) :~ (s1 <> s2)
+application = foldl app <$> atom <*> many (spanned (plicit term atom)) <?> "function application"
+  where app f@(_ :~ s1) (a :~ s2) = (f :$ a) :~ (s1 <> s2)
 
 type' = spanned (Type <$ keyword "Type")
 

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -3,7 +3,7 @@ module Path.Parser.Term where
 
 import Control.Applicative (Alternative(..), (<**>))
 import Data.Maybe (fromMaybe)
-import Path.Name
+import Path.Name hiding (name)
 import Path.Parser as Parser
 import Path.Plicity
 import Path.Parser.Mixfix

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -42,7 +42,7 @@ lambda = (do
         bind (v:vv) = wrap v <$> spanned (bind vv)
           where wrap (a :~ v1) (b :~ v2) = Lam a b :~ (v1 <> v2)
 
-hole = spanned (Hole . Id <$> ident (IdentifierStyle "hole" (char '?') (alphaNum <|> char '\'') reservedWords Identifier ReservedIdentifier))
+hole = spanned (Hole <$> ident (IdentifierStyle "hole" (char '?') (alphaNum <|> char '\'') reservedWords Identifier ReservedIdentifier))
 
 atom = var <|> type' <|> lambda <|> try (parens term) <|> hole
 

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -42,7 +42,7 @@ lambda = (do
         bind (v:vv) = wrap v <$> spanned (bind vv)
           where wrap (a :~ v1) (b :~ v2) = Lam a b :~ (v1 <> v2)
 
-hole = spanned (Hole <$> ident (IdentifierStyle "hole" (char '?') (alphaNum <|> char '\'') reservedWords Identifier ReservedIdentifier))
+hole = spanned (Hole <$ char '?' <*> optional (ident (IdentifierStyle "hole" letter (alphaNum <|> char '\'') reservedWords Identifier ReservedIdentifier)))
 
 atom = var <|> type' <|> lambda <|> try (parens term) <|> hole
 

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -16,7 +16,7 @@ type', var, hole, term, application, piType, functionType, lambda, atom :: Delta
 
 term = functionType
 
-application = atom <**> (flip (foldl wrap) <$> many (plicit term atom)) <?> "function application"
+application = foldl wrap <$> atom <*> many (plicit term atom) <?> "function application"
   where wrap f@(_ :~ s1) a@(_ :< (_ :~ s2)) = (f :$ a) :~ (s1 <> s2)
 
 type' = spanned (Type <$ keyword "Type")

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -22,10 +22,9 @@ application = foldl app <$> atom <*> many (spanned (plicit term atom)) <?> "func
 type' = spanned (Type <$ keyword "Type")
 
 piType = spanned (do
-  p :< (v, mult, ty) <- plicity ((,,) <$> name <* colon <*> optional multiplicity <*> term) <* op "->"
+  p :< (v, mult, ty) <- plicit binding (parens binding) <* op "->"
   Pi (p :< (Just v, fromMaybe (case p of { Ex -> More ; Im -> Zero }) mult, ty)) <$> functionType) <?> "dependent function type"
-  where plicity m = (Im :<) <$> braces m
-                <|> (Ex :<) <$> parens m
+  where binding = ((,,) <$> name <* colon <*> optional multiplicity <*> term)
 
 functionType = spanned ((,) <$> multiplicity <*> application <**> (flip (:->) <$ op "->" <*> functionType))
                 <|> application <**> (arrow <$ op "->" <*> functionType <|> pure id)

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -16,8 +16,8 @@ type', var, hole, term, application, piType, functionType, lambda, atom :: Delta
 
 term = functionType
 
-application = foldl wrap <$> atom <*> many (plicit term atom) <?> "function application"
-  where wrap f@(_ :~ s1) a@(_ :< (_ :~ s2)) = (f :$ a) :~ (s1 <> s2)
+application = foldl app <$> atom <*> many (plicit term atom) <?> "function application"
+  where app f@(_ :~ s1) a@(_ :< (_ :~ s2)) = (f :$ a) :~ (s1 <> s2)
 
 type' = spanned (Type <$ keyword "Type")
 

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -139,7 +139,7 @@ script :: ( Carrier sig m
           )
        => [FilePath]
        -> m ()
-script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (Value Name ::: Type Name)) (runError loop >>= either (print @Doc) pure)
+script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (Value (Name Gensym) ::: Type (Name Gensym))) (runError loop >>= either (print @Doc) pure)
   where loop = (prompt "λ: " >>= parseCommand >>= maybe loop runCommand . join)
           `catchError` (const loop <=< print @Doc)
         parseCommand str = do
@@ -159,7 +159,7 @@ script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (
             loop
           Show Modules -> do
             graph <- get
-            let ms = modules (graph :: ModuleGraph Qualified (Value Name ::: Type Name))
+            let ms = modules (graph :: ModuleGraph Qualified (Value (Name Gensym) ::: Type (Name Gensym)))
             unless (Prelude.null ms) $ print (tabulate2 space (map (moduleName &&& parens . pretty . modulePath) ms))
             loop
           Reload -> reload *> loop
@@ -169,7 +169,7 @@ script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (
             loop
           Command.Doc moduleName -> do
             m <- gets (Map.lookup moduleName . unModuleGraph)
-            case m :: Maybe (Module Qualified (Value Name ::: Type Name)) of
+            case m :: Maybe (Module Qualified (Value (Name Gensym) ::: Type (Name Gensym))) of
               Just m -> case moduleDocs m of
                 Just d  -> print (pretty d)
                 Nothing -> print (pretty "no docs for" <+> squotes (pretty moduleName))

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -203,7 +203,7 @@ script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (
           runReader (res :: Resolution) (runReader (ModuleName "(interpreter)") m)
         elaborate tm@(_ :~ span) = runReader span $ do
           ty <- inferType
-          tm' <- runRenamer (runReader Defn (resolveTerm tm))
+          tm' <- runRenamer (evalState (mempty :: Signature) (runReader Defn (resolveTerm tm)))
           runScope (define ty (elab tm'))
 
 basePackage :: Package

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -139,7 +139,7 @@ script :: ( Carrier sig m
           )
        => [FilePath]
        -> m ()
-script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (Value (Name Gensym) ::: Type (Name Gensym))) (runError loop >>= either (print @Doc) pure)
+script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (Value Gensym ::: Type Gensym)) (runError loop >>= either (print @Doc) pure)
   where loop = (prompt "λ: " >>= parseCommand >>= maybe loop runCommand . join)
           `catchError` (const loop <=< print @Doc)
         parseCommand str = do
@@ -159,7 +159,7 @@ script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (
             loop
           Show Modules -> do
             graph <- get
-            let ms = modules (graph :: ModuleGraph Qualified (Value (Name Gensym) ::: Type (Name Gensym)))
+            let ms = modules (graph :: ModuleGraph Qualified (Value Gensym ::: Type Gensym))
             unless (Prelude.null ms) $ print (tabulate2 space (map (moduleName &&& parens . pretty . modulePath) ms))
             loop
           Reload -> reload *> loop
@@ -169,7 +169,7 @@ script packageSources = evalState (ModuleGraph mempty :: ModuleGraph Qualified (
             loop
           Command.Doc moduleName -> do
             m <- gets (Map.lookup moduleName . unModuleGraph)
-            case m :: Maybe (Module Qualified (Value (Name Gensym) ::: Type (Name Gensym))) of
+            case m :: Maybe (Module Qualified (Value Gensym ::: Type Gensym)) of
               Just m -> case moduleDocs m of
                 Just d  -> print (pretty d)
                 Nothing -> print (pretty "no docs for" <+> squotes (pretty moduleName))

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -18,7 +18,7 @@ import Data.Int (Int64)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
 import Data.Traversable (for)
-import Path.Elab hiding (Signature)
+import Path.Elab
 import Path.Eval
 import Path.Module as Module
 import Path.Name

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -18,7 +18,7 @@ import Data.Int (Int64)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
 import Data.Traversable (for)
-import Path.Elab
+import Path.Elab hiding (Signature)
 import Path.Eval
 import Path.Module as Module
 import Path.Name

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -32,7 +32,7 @@ resolveTerm :: ( Carrier sig m
             => Spanned Surface.Surface
             -> m (Core Gensym)
 resolveTerm (term :~ span) = Ann span <$> case term of
-  Surface.Var v -> name Var Glo <$> resolveName v
+  Surface.Var v -> Var <$> resolveName v
   Surface.Lam (p :< v) b -> do
     v' <- gensym (maybe "lam" showUser v)
     local (insertLocal v v') (Lam (p :< v) . bind v' <$> resolveTerm b)

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -6,6 +6,7 @@ import Control.Effect.Reader hiding (Local)
 import Control.Effect.State
 import Data.List.NonEmpty as NonEmpty (NonEmpty(..), filter, nonEmpty, nub)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 -- import qualified Data.Set as Set
 import Path.Core as Core
 import Path.Error
@@ -34,7 +35,7 @@ resolveTerm (term :~ span) = Ann span <$> case term of
   (u, a) Surface.:-> b -> do
     v <- gensym "pi"
     Pi . (Ex :<) . (Nothing, u,) <$> resolveTerm a <*> (bind (Local v) <$> resolveTerm b)
-  Surface.Hole v -> Hole <$> resolveName (Id v)
+  Surface.Hole v -> Hole <$> resolveName (Id (fromMaybe "hole" v))
 
 
 data Mode = Decl | Defn

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -6,7 +6,6 @@ import Control.Effect.Reader hiding (Local)
 import Control.Effect.State
 import Data.List.NonEmpty as NonEmpty (NonEmpty(..), filter, nonEmpty, nub)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
 -- import qualified Data.Set as Set
 import Path.Core as Core
 import Path.Error
@@ -19,7 +18,7 @@ import qualified Path.Surface as Surface
 import Prelude hiding (pi)
 import Text.Trifecta.Rendering (Span, Spanned(..))
 
-type Signature = Map.Map (Maybe String) Gensym
+type Signature = Map.Map String Gensym
 
 resolveTerm :: ( Carrier sig m
                , Member (Error Doc) sig
@@ -134,13 +133,14 @@ resolveMeta :: ( Carrier sig m
                )
             => Maybe String
             -> m Gensym
-resolveMeta m = do
+resolveMeta (Just m) = do
   found <- gets (Map.lookup m)
   case found of
     Just meta -> pure meta
     Nothing   -> do
-      n <- gensym (fromMaybe "meta" m)
+      n <- gensym m
       n <$ modify (Map.insert m n)
+resolveMeta Nothing = gensym "meta"
 
 filterResolution :: (Name -> Bool) -> Resolution -> Resolution
 filterResolution f = Resolution . Map.mapMaybe matches . unResolution

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -6,7 +6,7 @@ import Control.Effect.Reader hiding (Local)
 import Control.Effect.State
 import Data.List.NonEmpty as NonEmpty (NonEmpty(..), filter, nonEmpty, nub)
 import qualified Data.Map as Map
-import qualified Data.Set as Set
+-- import qualified Data.Set as Set
 import Path.Core as Core
 import Path.Error
 import Path.Module
@@ -14,7 +14,7 @@ import Path.Name
 import Path.Plicity
 import Path.Pretty
 import qualified Path.Surface as Surface
-import Path.Usage
+-- import Path.Usage
 import Prelude hiding (pi)
 import Text.Trifecta.Rendering (Span, Spanned(..))
 
@@ -45,13 +45,13 @@ resolveDecl (decl :~ span) = fmap (:~ span) . runReader span $ case decl of
   Declare n ty -> do
     res <- get
     moduleName <- ask
-    let vs = fvs ty Set.\\ Map.keysSet (unResolution res)
-        generalize ty = foldr bind ty vs
-        bind n ty = do
-          n' <- gensym (showUser n)
-          local (insertLocal (Just n) n') $
-            Pi (Im :< (Just n, Zero, Type)) . Core.bind (Local n') <$> ty -- FIXME: insert metavariables for the type
-    ty' <- runReader (res :: Resolution) (runReader Decl (generalize (resolveTerm ty)))
+    -- let vs = fvs ty Set.\\ Map.keysSet (unResolution res)
+    --     generalize ty = foldr bind ty vs
+    --     bind n ty = do
+    --       n' <- gensym (showUser n)
+    --       local (insertLocal (Just n) n') $
+    --         Pi (Im :< (Just n, Zero, Type)) . Core.bind (Local n') <$> ty -- FIXME: insert metavariables for the type
+    ty' <- runReader (res :: Resolution) (runReader Decl (resolveTerm ty))
     Declare (moduleName :.: n) ty' <$ modify (insertGlobal n moduleName)
   Define n tm -> do
     res <- get

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -32,7 +32,7 @@ resolveTerm :: ( Carrier sig m
             => Spanned Surface.Surface
             -> m (Core Name)
 resolveTerm (term :~ span) = Ann span <$> case term of
-  Surface.Var v -> Var <$> resolveName v
+  Surface.Var v -> name <$> resolveName v
   Surface.Lam (p :< v) b -> do
     v' <- gensym (maybe "lam" showUser v)
     local (insertLocal v v') (Lam (p :< v) . bind (Local v') <$> resolveTerm b)

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -34,7 +34,7 @@ resolveTerm (term :~ span) = Ann span <$> case term of
   (u, a) Surface.:-> b -> do
     v <- gensym "pi"
     Pi . (Ex :<) . (Nothing, u,) <$> resolveTerm a <*> (bind (Local v) <$> resolveTerm b)
-  Surface.Hole v -> Hole <$> resolveName v
+  Surface.Hole v -> Hole <$> resolveName (Id v)
 
 
 data Mode = Decl | Defn

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -24,12 +24,12 @@ resolveTerm :: (Carrier sig m, Member (Error Doc) sig, Member Naming sig, Member
 resolveTerm (term :~ span) = Ann span <$> case term of
   Surface.Var v -> Var <$> resolveName v
   Surface.Lam (p :< v) b -> do
-    v' <- gensym (maybe "lam" show v)
+    v' <- gensym (maybe "lam" showUser v)
     local (insertLocal v v') (Lam (p :< v) . bind (Local v') <$> resolveTerm b)
   f Surface.:$ a -> (:$) <$> resolveTerm f <*> traverse resolveTerm a
   Surface.Type -> pure Type
   Surface.Pi (ie :< (v, u, t)) b -> do
-    v' <- gensym (maybe "pi" show v)
+    v' <- gensym (maybe "pi" showUser v)
     Pi . (ie :<) . (v, u,) <$> resolveTerm t <*> local (insertLocal v v') (bind (Local v') <$> resolveTerm b)
   (u, a) Surface.:-> b -> do
     v <- gensym "pi"

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -32,7 +32,7 @@ resolveTerm :: ( Carrier sig m
             => Spanned Surface.Surface
             -> m (Core Gensym)
 resolveTerm (term :~ span) = Ann span <$> case term of
-  Surface.Var v -> name <$> resolveName v
+  Surface.Var v -> name Var Glo <$> resolveName v
   Surface.Lam (p :< v) b -> do
     v' <- gensym (maybe "lam" showUser v)
     local (insertLocal v v') (Lam (p :< v) . bind v' <$> resolveTerm b)

--- a/src/Path/Renamer.hs
+++ b/src/Path/Renamer.hs
@@ -29,7 +29,7 @@ resolveTerm (term :~ span) = Ann span <$> case term of
   f Surface.:$ a -> (:$) <$> resolveTerm f <*> traverse resolveTerm a
   Surface.Type -> pure Type
   Surface.Pi (ie :< (v, u, t)) b -> do
-    v' <- gensym (maybe "lam" show v)
+    v' <- gensym (maybe "pi" show v)
     Pi . (ie :<) . (v, u,) <$> resolveTerm t <*> local (insertLocal v v') (bind (Local v') <$> resolveTerm b)
   (u, a) Surface.:-> b -> do
     v <- gensym "pi"

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -8,24 +8,24 @@ import Path.Name
 import Path.Pretty
 import Path.Value hiding (Scope(..))
 
-newtype Entry = Entry { unEntry :: Maybe (Value Name) ::: Type Name }
+newtype Entry a = Entry { unEntry :: Maybe a ::: a }
   deriving (Eq, Ord, Show)
 
-entryType :: Entry -> Type Name
+entryType :: Entry a -> a
 entryType = typedType . unEntry
 
-entryValue :: Entry -> Maybe (Value Name)
+entryValue :: Entry a -> Maybe a
 entryValue = typedTerm . unEntry
 
-instance Pretty Entry where
+instance Pretty a => Pretty (Entry a) where
   pretty (Entry (Nothing ::: ty)) =         cyan colon <+> pretty ty
   pretty (Entry (Just v  ::: ty)) = align $ cyan colon <+> pretty ty <> hardline <> cyan (pretty "=") <+> pretty v
 
 
-newtype Scope = Scope { unScope :: Map.Map Qualified Entry }
+newtype Scope = Scope { unScope :: Map.Map Qualified (Entry (Type Name)) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
-lookup :: Qualified -> Scope -> Maybe Entry
+lookup :: Qualified -> Scope -> Maybe (Entry (Type Name))
 lookup q = Map.lookup q . unScope
 
 null :: Scope -> Bool
@@ -34,13 +34,13 @@ null = Map.null . unScope
 union :: Scope -> Scope -> Scope
 union = (<>)
 
-filter :: (Qualified -> Entry -> Bool) -> Scope -> Scope
+filter :: (Qualified -> Entry (Type Name) -> Bool) -> Scope -> Scope
 filter = under . Map.filterWithKey
 
-insert :: Qualified -> Entry -> Scope -> Scope
+insert :: Qualified -> Entry (Type Name) -> Scope -> Scope
 insert q = under . Map.insert q
 
-under :: (Map.Map Qualified Entry -> Map.Map Qualified Entry) -> Scope -> Scope
+under :: (Map.Map Qualified (Entry (Type Name)) -> Map.Map Qualified (Entry (Type Name))) -> Scope -> Scope
 under = coerce
 
 instance Pretty Scope where

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -22,10 +22,10 @@ instance Pretty a => Pretty (Entry a) where
   pretty (Entry (Just v  ::: ty)) = align $ cyan colon <+> pretty ty <> hardline <> cyan (pretty "=") <+> pretty v
 
 
-newtype Scope = Scope { unScope :: Map.Map Qualified (Entry (Type Name)) }
+newtype Scope = Scope { unScope :: Map.Map Qualified (Entry (Type (Name Gensym))) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
-lookup :: Qualified -> Scope -> Maybe (Entry (Type Name))
+lookup :: Qualified -> Scope -> Maybe (Entry (Type (Name Gensym)))
 lookup q = Map.lookup q . unScope
 
 null :: Scope -> Bool
@@ -34,13 +34,13 @@ null = Map.null . unScope
 union :: Scope -> Scope -> Scope
 union = (<>)
 
-filter :: (Qualified -> Entry (Type Name) -> Bool) -> Scope -> Scope
+filter :: (Qualified -> Entry (Type (Name Gensym)) -> Bool) -> Scope -> Scope
 filter = under . Map.filterWithKey
 
-insert :: Qualified -> Entry (Type Name) -> Scope -> Scope
+insert :: Qualified -> Entry (Type (Name Gensym)) -> Scope -> Scope
 insert q = under . Map.insert q
 
-under :: (Map.Map Qualified (Entry (Type Name)) -> Map.Map Qualified (Entry (Type Name))) -> Scope -> Scope
+under :: (Map.Map Qualified (Entry (Type (Name Gensym))) -> Map.Map Qualified (Entry (Type (Name Gensym)))) -> Scope -> Scope
 under = coerce
 
 instance Pretty Scope where

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -22,10 +22,10 @@ instance Pretty a => Pretty (Entry a) where
   pretty (Entry (Just v  ::: ty)) = align $ cyan colon <+> pretty ty <> hardline <> cyan (pretty "=") <+> pretty v
 
 
-newtype Scope = Scope { unScope :: Map.Map Qualified (Entry (Type (Name Gensym))) }
+newtype Scope = Scope { unScope :: Map.Map Qualified (Entry (Type Gensym)) }
   deriving (Eq, Monoid, Ord, Semigroup, Show)
 
-lookup :: Qualified -> Scope -> Maybe (Entry (Type (Name Gensym)))
+lookup :: Qualified -> Scope -> Maybe (Entry (Type Gensym))
 lookup q = Map.lookup q . unScope
 
 null :: Scope -> Bool
@@ -34,13 +34,13 @@ null = Map.null . unScope
 union :: Scope -> Scope -> Scope
 union = (<>)
 
-filter :: (Qualified -> Entry (Type (Name Gensym)) -> Bool) -> Scope -> Scope
+filter :: (Qualified -> Entry (Type Gensym) -> Bool) -> Scope -> Scope
 filter = under . Map.filterWithKey
 
-insert :: Qualified -> Entry (Type (Name Gensym)) -> Scope -> Scope
+insert :: Qualified -> Entry (Type Gensym) -> Scope -> Scope
 insert q = under . Map.insert q
 
-under :: (Map.Map Qualified (Entry (Type (Name Gensym))) -> Map.Map Qualified (Entry (Type (Name Gensym)))) -> Scope -> Scope
+under :: (Map.Map Qualified (Entry (Type Gensym)) -> Map.Map Qualified (Entry (Type Gensym))) -> Scope -> Scope
 under = coerce
 
 instance Pretty Scope where

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -8,22 +8,18 @@ import Path.Name
 import Path.Pretty
 import Path.Value hiding (Scope(..))
 
-data Entry
-  = Decl (Type Name)
-  | Defn (Value Name ::: Type Name)
+newtype Entry = Entry { unEntry :: Maybe (Value Name) ::: Type Name }
   deriving (Eq, Ord, Show)
 
 entryType :: Entry -> Type Name
-entryType (Decl        ty)  = ty
-entryType (Defn (_ ::: ty)) = ty
+entryType = typedType . unEntry
 
 entryValue :: Entry -> Maybe (Value Name)
-entryValue (Defn (v ::: _)) = Just v
-entryValue _                = Nothing
+entryValue = typedTerm . unEntry
 
 instance Pretty Entry where
-  pretty (Decl        ty)  =         cyan colon <+> pretty ty
-  pretty (Defn (v ::: ty)) = align $ cyan colon <+> pretty ty <> hardline <> cyan (pretty "=") <+> pretty v
+  pretty (Entry (Nothing ::: ty)) =         cyan colon <+> pretty ty
+  pretty (Entry (Just v  ::: ty)) = align $ cyan colon <+> pretty ty <> hardline <> cyan (pretty "=") <+> pretty v
 
 
 newtype Scope = Scope { unScope :: Map.Map Qualified Entry }

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -194,13 +194,16 @@ distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)
 solve :: ( Carrier sig m
          , Member (State Blocked) sig
          , Member (State Queue) sig
+         , Member (State Signature) sig
          , Member (State Substitution) sig
          )
       => Gensym
       -> Value Meta
       -> m ()
 solve m v = do
-  modify (Substitution . Map.insert m v . fmap (apply (Substitution (Map.singleton m v))) . unSubstitution)
+  let subst = Substitution (Map.singleton m v)
+  modify (Substitution . Map.insert m v . fmap (apply subst) . unSubstitution)
+  modify (Signature . fmap (apply subst) . unSignature)
   (unblocked, blocked) <- gets (Set.partition (isBlockedOn (Meta m)))
   enqueueAll unblocked
   put blocked

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -121,7 +121,7 @@ solver constraints = execState Map.empty $ do
   queue <- execState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) $ do
     enqueueAll constraints
     step
-  unless (null queue)   (stalledConstraints (toList queue))
+  unless (null queue) (stalledConstraints (toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -191,7 +191,14 @@ free _          = Nothing
 distinct :: (Foldable t, Ord a) => t a -> Maybe (t a)
 distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)
 
-solve :: (Carrier sig m, Member (State Blocked) sig, Member (State Queue) sig, Member (State Substitution) sig) => Gensym -> Value Meta -> m ()
+solve :: ( Carrier sig m
+         , Member (State Blocked) sig
+         , Member (State Queue) sig
+         , Member (State Substitution) sig
+         )
+      => Gensym
+      -> Value Meta
+      -> m ()
 solve m v = do
   modify (Substitution . Map.insert m v . fmap (apply (Substitution (Map.singleton m v))) . unSubstitution)
   (unblocked, blocked) <- gets (Set.partition (isBlockedOn (Meta m)))

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -126,7 +126,7 @@ solver constraints = do
     enqueueAll constraints
     step
   sig <- get
-  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig subst (unsimplifiable <> toList queue))
+  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -25,9 +25,6 @@ import           Text.Trifecta.Rendering (Spanned(..))
 type Blocked = Set.Set (Spanned (Constraint Meta))
 type Queue = Seq.Seq (Spanned (Constraint Meta))
 
-newtype Signature = Signature { unSignature :: Map.Map Gensym (Value Meta) }
-  deriving (Eq, Monoid, Ord, Semigroup, Show)
-
 -- FIXME: we need constraint dependencies to ensure that we e.g. δ-reduce a type like Either L R and solve the π type unification constraint before we try to solve whatever we typed using it
 
 simplify :: ( Carrier sig m

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -125,7 +125,8 @@ solver constraints = execState mempty $ do
   (queue, unsimplifiable) <- runState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) . execWriter $ do
     enqueueAll constraints
     step
-  unless (null unsimplifiable && null queue) (unsimplifiableConstraints (unsimplifiable <> toList queue))
+  sig <- get
+  unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -182,12 +182,12 @@ dequeue = gets Seq.viewl >>= \case
   h Seq.:< q -> Just h <$ put q
 
 pattern :: Type Meta -> Maybe (Gensym, Stack (Plicit Meta))
-pattern (Meta m :$ sp) = (,) m <$> (traverse (traverse free) sp >>= distinct)
+pattern (Meta m :$ sp) = (,) m <$> (traverse (traverse bound) sp >>= distinct)
 pattern _              = Nothing
 
-free :: Type Meta -> Maybe Meta
-free (Name v :$ Nil) = Just (Name v)
-free _               = Nothing
+bound :: Type Meta -> Maybe Meta
+bound (Name v :$ Nil) = Just (Name v)
+bound _               = Nothing
 
 distinct :: (Foldable t, Ord a) => t a -> Maybe (t a)
 distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -185,9 +185,9 @@ pattern :: Type Meta -> Maybe (Gensym, Stack (Plicit Meta))
 pattern (Meta m :$ sp) = (,) m <$> (traverse (traverse free) sp >>= distinct)
 pattern _              = Nothing
 
-free :: Type a -> Maybe a
-free (v :$ Nil) = Just v
-free _          = Nothing
+free :: Type Meta -> Maybe Meta
+free (Name v :$ Nil) = Just (Name v)
+free _               = Nothing
 
 distinct :: (Foldable t, Ord a) => t a -> Maybe (t a)
 distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -18,6 +18,7 @@ import           Path.Plicity
 import           Path.Pretty
 import           Path.Scope as Scope hiding (null)
 import           Path.Stack
+import           Path.Usage
 import           Path.Value as Value hiding (Scope (..))
 import           Prelude hiding (pi)
 import           Text.Trifecta.Rendering (Spanned(..))
@@ -99,7 +100,9 @@ simplify (constraint :~ span) = do
 
         exists ctx ty = do
           n <- gensym "meta"
-          modify (Signature . Map.insert n ty . unSignature)
+          let f (n ::: t) = Ex :< (qlocal n, More) ::: t
+              ty' = Value.pis (f <$> Context.unContext ctx) ty
+          modify (Signature . Map.insert n ty' . unSignature)
           pure (pure (Meta n) Value.$$* ((Ex :<) . pure . qlocal <$> Context.vars ctx))
 
         blocked (Meta _ :$ _) = True

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -24,6 +24,7 @@ import           Text.Trifecta.Rendering (Spanned(..))
 
 type Blocked = Set.Set (Spanned (Constraint Meta))
 type Queue = Seq.Seq (Spanned (Constraint Meta))
+type Signature = Map.Map Gensym (Value Meta)
 
 -- FIXME: we need constraint dependencies to ensure that we e.g. δ-reduce a type like Either L R and solve the π type unification constraint before we try to solve whatever we typed using it
 

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -44,7 +44,7 @@ simplify (constraint :~ span) = do
   execWriter (go scope ctx eqn)
   where go scope ctx = \case
           (tm1 :===: tm2) ::: _ | tm1 == tm2 -> pure ()
-          (Meta m1 :$ _ :===: Meta m2 :$ _) ::: _
+          (Local (Meta m1) :$ _ :===: Local (Meta m2) :$ _) ::: _
             | m1 == m2 -> pure ()
           c@((t1 :===: t2) ::: _)
             | blocked t1 || blocked t2 -> tell (Set.singleton (binds ctx c :~ span))
@@ -53,7 +53,7 @@ simplify (constraint :~ span) = do
               go scope ctx ((t1 :===: t2) ::: Type)
               n <- gensym "pi"
               -- FIXME: this should insert some sort of dependency
-              go scope (Context.insert (n ::: t1) ctx) ((Value.instantiate (pure (qlocal n)) b1 :===: Value.instantiate (pure (qlocal n)) b2) ::: Type)
+              go scope (Context.insert (n ::: t1) ctx) ((Value.instantiate (pure (Name n)) b1 :===: Value.instantiate (pure (Name n)) b2) ::: Type)
           (Pi (Im :< (_, t1)) b1 :===: tm2) ::: Type -> do
             n <- exists ctx t1
             go scope ctx ((Value.instantiate n b1 :===: tm2) ::: Type)
@@ -63,52 +63,52 @@ simplify (constraint :~ span) = do
           (Lam p1 f1 :===: Lam p2 f2) ::: Pi (pt :< (_, t)) b
             | p1 == p2, p1 == pt -> do
               n <- gensym "lam"
-              go scope (Context.insert (n ::: t) ctx) ((Value.instantiate (pure (qlocal n)) f1 :===: Value.instantiate (pure (qlocal n)) f2) ::: Value.instantiate (pure (qlocal n)) b)
+              go scope (Context.insert (n ::: t) ctx) ((Value.instantiate (pure (Name n)) f1 :===: Value.instantiate (pure (Name n)) f2) ::: Value.instantiate (pure (Name n)) b)
           (t1 :===: t2) ::: Pi (Im :< (u, t)) b -> do
-            n <- qlocal <$> gensym "lam"
+            n <- Name <$> gensym "lam"
             go scope ctx ((Value.lam (Im :< n) t1 :===: Value.lam (Im :< n) t2) ::: Pi (Im :< (u, t)) b)
-          (f1@(Name (Global _)) :$ sp1 :===: f2@(Name (Global _)) :$ sp2) ::: ty
+          (f1@(Global _) :$ sp1 :===: f2@(Global _) :$ sp2) ::: ty
             | Just t1 <- whnf scope (f1 :$ sp1)
             , Just t2 <- whnf scope (f2 :$ sp2) ->
               go scope ctx ((t1 :===: t2) ::: ty)
-          (f1@(Name (Global _)) :$ sp1 :===: t2) ::: ty
+          (f1@(Global _) :$ sp1 :===: t2) ::: ty
             | Just t1 <- whnf scope (f1 :$ sp1) ->
               go scope ctx ((t1 :===: t2) ::: ty)
-          (t1 :===: f2@(Name (Global _)) :$ sp2) ::: ty
+          (t1 :===: f2@(Global _) :$ sp2) ::: ty
             | Just t2 <- whnf scope (f2 :$ sp2) ->
               go scope ctx ((t1 :===: t2) ::: ty)
-          (Name (Local f1) :$ sp1 :===: Name (Local f2) :$ sp2) ::: _
+          (Local (Name f1) :$ sp1 :===: Local (Name f2) :$ sp2) ::: _
             | f1 == f2
             , length sp1 == length sp2 -> do
               let simplifySpine ctx ty ((_ :< a1, _ :< a2) : as) = do
                     n <- gensym "spine"
-                    case Value.unpi (qlocal n) ty of
+                    case Value.unpi (Name n) ty of
                       Just (_ ::: t, b) -> go scope ctx ((a1 :===: a2) ::: t) >> simplifySpine (Context.insert (n ::: t) ctx) b as
                       Nothing -> pure ()
                   simplifySpine _ _ _ = pure ()
-              t <- maybe (runReader span (freeVariable (qlocal f1))) pure (Context.lookup f1 ctx)
+              t <- maybe (runReader span (freeVariable (Name f1))) pure (Context.lookup f1 ctx)
               simplifySpine ctx t (zip (toList sp1) (toList sp2))
           (tm1 :===: Lam p2 b2) ::: ty@(Pi (_ :< (_, _)) _) -> do
             n <- gensym "lam"
-            go scope ctx ((lam (p2 :< qlocal n) (tm1 $$ (p2 :< pure (qlocal n))) :===: Lam p2 b2) ::: ty)
+            go scope ctx ((lam (p2 :< Name n) (tm1 $$ (p2 :< pure (Name n))) :===: Lam p2 b2) ::: ty)
           (Lam p1 b1 :===: tm2) ::: ty@(Pi (_ :< (_, _)) _) -> do
             n <- gensym "lam"
-            go scope ctx ((Lam p1 b1 :===: lam (p1 :< qlocal n) (tm2 $$ (p1 :< pure (qlocal n)))) ::: ty)
+            go scope ctx ((Lam p1 b1 :===: lam (p1 :< Name n) (tm2 $$ (p1 :< pure (Name n)))) ::: ty)
           c@((t1 :===: t2) ::: _)
             | blocked t1 || blocked t2 -> tell (Set.singleton (binds ctx c :~ span))
             | otherwise                -> tell [binds ctx c :~ span]
 
         exists ctx ty = do
           n <- gensym "meta"
-          let f (n ::: t) = Ex :< (qlocal n, More) ::: t
+          let f (n ::: t) = Ex :< (Name n, More) ::: t
               ty' = Value.pis (f <$> Context.unContext ctx) ty
           modify (Signature . Map.insert n ty' . unSignature)
-          pure (pure (Meta n) Value.$$* ((Ex :<) . pure . qlocal <$> Context.vars ctx))
+          pure (pure (Meta n) Value.$$* ((Ex :<) . pure . Name <$> Context.vars ctx))
 
-        blocked (Meta _ :$ _) = True
-        blocked _             = False
+        blocked (Local (Meta _) :$ _) = True
+        blocked _                     = False
 
-        whnf scope (Name (Global n) Value.:$ sp) = do
+        whnf scope (Global n Value.:$ sp) = do
           entry <- Scope.lookup n scope
           val <- entryValue entry
           let val' = weaken val $$* sp
@@ -182,12 +182,12 @@ dequeue = gets Seq.viewl >>= \case
   h Seq.:< q -> Just h <$ put q
 
 pattern :: Type Meta -> Maybe (Gensym, Stack (Plicit Meta))
-pattern (Meta m :$ sp) = (,) m <$> (traverse (traverse bound) sp >>= distinct)
-pattern _              = Nothing
+pattern (Local (Meta m) :$ sp) = (,) m <$> (traverse (traverse bound) sp >>= distinct)
+pattern _                      = Nothing
 
 bound :: Type Meta -> Maybe Meta
-bound (Name v :$ Nil) = Just (Name v)
-bound _               = Nothing
+bound (Local v :$ Nil) = Just v
+bound _                = Nothing
 
 distinct :: (Foldable t, Ord a) => t a -> Maybe (t a)
 distinct sp = sp <$ guard (length (foldMap Set.singleton sp) == length sp)

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -93,7 +93,7 @@ simplify (constraint :~ span) = do
             go scope ctx ((Lam p1 b1 :===: lam (p1 :< qlocal n) (tm2 $$ (p1 :< pure (qlocal n)))) ::: ty)
           c@((t1 :===: t2) ::: _)
             | blocked t1 || blocked t2 -> tell (Set.singleton (binds ctx c :~ span))
-            | otherwise                -> unsimplifiableConstraint (binds ctx c :~ span)
+            | otherwise                -> unsimplifiableConstraint [binds ctx c :~ span]
 
         exists ctx _ = do
           n <- Meta <$> gensym "meta"

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, LambdaCase, TypeApplications, TypeOperators #-}
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeApplications, TypeOperators #-}
 module Path.Solver where
 
 import           Control.Effect
@@ -24,7 +24,9 @@ import           Text.Trifecta.Rendering (Spanned(..))
 
 type Blocked = Set.Set (Spanned (Constraint Meta))
 type Queue = Seq.Seq (Spanned (Constraint Meta))
-type Signature = Map.Map Gensym (Value Meta)
+
+newtype Signature = Signature { unSignature :: Map.Map Gensym (Value Meta) }
+  deriving (Eq, Monoid, Ord, Semigroup, Show)
 
 -- FIXME: we need constraint dependencies to ensure that we e.g. δ-reduce a type like Either L R and solve the π type unification constraint before we try to solve whatever we typed using it
 

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -121,12 +121,12 @@ solver :: ( Carrier sig m
           )
        => Set.Set (Spanned (Constraint Meta))
        -> m Substitution
-solver constraints = execState mempty $ do
-  (queue, unsimplifiable) <- runState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) . execWriter $ do
+solver constraints = do
+  (subst, (queue, unsimplifiable)) <- runState (mempty :: Substitution) . runState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) . execWriter $ do
     enqueueAll constraints
     step
   sig <- get
-  unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
+  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -93,7 +93,7 @@ simplify (constraint :~ span) = do
             go scope ctx ((Lam p1 b1 :===: lam (p1 :< qlocal n) (tm2 $$ (p1 :< pure (qlocal n)))) ::: ty)
           c@((t1 :===: t2) ::: _)
             | blocked t1 || blocked t2 -> tell (Set.singleton (binds ctx c :~ span))
-            | otherwise                -> unsimplifiableConstraint [binds ctx c :~ span]
+            | otherwise                -> unsimplifiableConstraints [binds ctx c :~ span]
 
         exists ctx _ = do
           n <- Meta <$> gensym "meta"
@@ -121,7 +121,7 @@ solver constraints = execState Map.empty $ do
   queue <- execState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) $ do
     enqueueAll constraints
     step
-  unless (null queue) (unsimplifiableConstraint (toList queue))
+  unless (null queue) (unsimplifiableConstraints (toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -121,12 +121,12 @@ solver :: ( Carrier sig m
           )
        => Set.Set (Spanned (Constraint Meta))
        -> m Substitution
-solver constraints = do
-  (subst, (queue, unsimplifiable)) <- runState (mempty :: Substitution) . runState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) . execWriter $ do
+solver constraints = execState mempty $ do
+  (queue, unsimplifiable) <- runState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) . execWriter $ do
     enqueueAll constraints
     step
   sig <- get
-  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
+  unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -126,7 +126,7 @@ solver constraints = do
     enqueueAll constraints
     step
   sig <- get
-  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig (unsimplifiable <> toList queue))
+  subst <$ unless (null unsimplifiable && null queue) (unsimplifiableConstraints sig subst (unsimplifiable <> toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Solver.hs
+++ b/src/Path/Solver.hs
@@ -121,7 +121,7 @@ solver constraints = execState Map.empty $ do
   queue <- execState (Seq.empty :: Queue) . evalState (Set.empty :: Blocked) $ do
     enqueueAll constraints
     step
-  unless (null queue) (stalledConstraints (toList queue))
+  unless (null queue) (unsimplifiableConstraint (toList queue))
 
 step :: ( Carrier sig m
         , Effect sig

--- a/src/Path/Surface.hs
+++ b/src/Path/Surface.hs
@@ -12,6 +12,6 @@ data Surface
   | Spanned Surface :$ Plicit (Spanned Surface)
   | Type
   | Pi (Plicit (Maybe User, Usage, Spanned Surface)) (Spanned Surface)
-  | Hole User
+  | Hole String
   | (Usage, Spanned Surface) :-> Spanned Surface
   deriving (Eq, Ord, Show)

--- a/src/Path/Surface.hs
+++ b/src/Path/Surface.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase, MultiParamTypeClasses #-}
 module Path.Surface where
 
-import qualified Data.Set as Set
 import Path.Name
 import Path.Plicity
 import Path.Usage
@@ -16,15 +15,3 @@ data Surface
   | Hole User
   | (Usage, Spanned Surface) :-> Spanned Surface
   deriving (Eq, Ord, Show)
-
-instance FreeVariables User Surface where
-  fvs = \case
-    Var v -> Set.singleton v
-    Lam (_ :< Just v) b -> Set.delete v (fvs b)
-    Lam (_ :< Nothing)  b -> fvs b
-    f :$ (_ :< a) -> fvs f <> fvs a
-    Type -> Set.empty
-    Pi (_ :< (Just v,  _, t)) b -> fvs t <> Set.delete v (fvs b)
-    Pi (_ :< (Nothing, _, t)) b -> fvs t <> fvs b
-    Hole v -> Set.singleton v
-    (_, a) :-> b -> fvs a <> fvs b

--- a/src/Path/Surface.hs
+++ b/src/Path/Surface.hs
@@ -12,6 +12,6 @@ data Surface
   | Spanned Surface :$ Plicit (Spanned Surface)
   | Type
   | Pi (Plicit (Maybe User, Usage, Spanned Surface)) (Spanned Surface)
-  | Hole String
+  | Hole (Maybe String)
   | (Usage, Spanned Surface) :-> Spanned Surface
   deriving (Eq, Ord, Show)

--- a/src/Path/Value.hs
+++ b/src/Path/Value.hs
@@ -34,7 +34,7 @@ prettyValue localName = go
             b'' <- go b'
             pure (prec 0 (align (group (cyan backslash <+> foldr (var (fvs b')) (linebreak <> cyan dot <+> prettyPrec 0 b'') as))))
             where var vs (p :< n) rest
-                    | n `Set.member` vs = prettyPlicity False (p :< pretty n)   <+> rest
+                    | n `Set.member` vs = prettyPlicity False (p :< pretty (Local n))   <+> rest
                     | otherwise         = prettyPlicity False (p :< pretty '_') <+> rest
           Type -> pure (atom (yellow (pretty "Type")))
           v@Pi{} -> do
@@ -51,7 +51,7 @@ prettyValue localName = go
                   l = flatAlt (space <> space <> space) mempty
                   prettyPi (p :< (n, u) ::: t) isUsed = do
                     t' <- withPi p u <$> go t
-                    pure $! prettyPlicity isUsed (p :< if isUsed then pretty (n ::: t') else t')
+                    pure $! prettyPlicity isUsed (p :< if isUsed then pretty (Local n ::: t') else t')
           f :$ sp -> do
             sp' <- traverse prettyArg (toList sp)
             pure (if null sp then


### PR DESCRIPTION
This PR attempts to handle implicits in a more principled manner. We want to be able to ensure that:

```
fix : { a : Type } -> { b : Type } -> ((a -> b) -> a -> b) -> a -> b
fix = \ {a} {b} f . f (fix {a} {b} f)
≡
fix : { a : ? } -> { b : ? } -> ((a -> b) -> a -> b) -> a -> b
fix = \ {a} {b} f . f (fix {?} {?} f)
≡
fix : ((a -> b) -> a -> b) -> a -> b
fix = \ f . f (fix f)
```