### PR TITLE
Fancily-typed variable binding

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -56,7 +56,6 @@ library
                      , terminal-size
                      , text
                      , unordered-containers
-                     , validation
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Weverything -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-name-shadowing -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -78,6 +78,9 @@ generalizeType ty = name undefined id <$> uncurry pis (traverse (traverse f) ty)
   where f name = (Set.singleton (Local name ::: type'), name)
 
 
+instance Pretty a => Pretty (Term Core a) where
+  pretty = prettyTerm prettyCore
+
 prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Core f (m Prec) -> m Prec
 prettyCore go = \case
   Lam b -> do

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TupleSections, TypeApplications, TypeOperators #-}
+{-# LANGUAGE DataKinds, DeriveAnyClass, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TupleSections, TypeApplications, TypeOperators #-}
 module Path.Core where
 
 import           Control.Applicative (Alternative (..))
@@ -37,6 +37,9 @@ instance RightModule Core where
 lam :: (Eq a, Carrier sig m, Member Core sig) => a -> m a -> m a
 lam n b = send (Lam (bind1 n b))
 
+lamFin :: (Carrier sig m, Member Core sig) => m (Var (Fin ('S n)) a) -> m (Var (Fin n) a)
+lamFin b = send (Lam (toScopeFin b))
+
 lams :: (Eq a, Foldable t, Carrier sig m, Member Core sig) => t a -> m a -> m a
 lams names body = foldr lam body names
 
@@ -61,6 +64,9 @@ type' = send Type
 
 pi :: (Eq a, Carrier sig m, Member Core sig) => a ::: m a -> m a -> m a
 pi (n ::: t) b = send (Pi t (bind1 n b))
+
+piFin :: (Carrier sig m, Member Core sig) => m (Var (Fin n) a) -> m (Var (Fin ('S n)) a) -> m (Var (Fin n) a)
+piFin t b = send (Pi t (toScopeFin b))
 
 -- | Wrap a type in a sequence of pi bindings.
 pis :: (Eq a, Foldable t, Carrier sig m, Member Core sig) => t (a ::: m a) -> m a -> m a

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -3,10 +3,13 @@ module Path.Core where
 
 import           Control.Applicative (Alternative (..))
 import           Control.Effect.Carrier
+import           Control.Effect.Reader hiding (Local)
+import           Control.Effect.Writer
 import           Control.Monad.Module
 import qualified Data.Set as Set
 import           GHC.Generics (Generic1)
 import           Path.Name
+import           Path.Pretty
 import           Path.Scope
 import           Path.Syntax
 import           Path.Term
@@ -73,6 +76,29 @@ unpi _ _                                 = empty
 generalizeType :: Ord n => Term Core (Name n) -> Term Core Qualified
 generalizeType ty = name undefined id <$> uncurry pis (traverse (traverse f) ty)
   where f name = (Set.singleton (Local name ::: type'), name)
+
+
+prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Core f (m Prec) -> m Prec
+prettyCore go = \case
+  Lam b -> do
+    (n, b') <- binding go pretty b
+    pure (prec 0 (pretty (cyan backslash) <+> pretty n </> cyan dot <+> withPrec 0 b'))
+  f :$ a -> do
+    f' <- withPrec 10 <$> go f
+    a' <- withPrec 11 <$> go a
+    pure (prec 10 (f' <+> a'))
+  Let v b -> do
+    v' <- withPrec 0 <$> go v
+    (n, b') <- binding go prettyMeta b
+    pure (prec 0 (magenta (pretty "let") <+> pretty (n := v') </> magenta dot <+> withPrec 0 b'))
+  Type -> pure (atom (yellow (pretty "Type")))
+  Pi t b -> do
+    t' <- withPrec 1 <$> go t
+    (fvs, (n, b')) <- listen (binding go pretty b)
+    let t'' | n `Set.member` fvs = parens (pretty (n ::: t'))
+            | otherwise          = t'
+    pure (prec 0 (t'' </> arrow <+> withPrec 0 b'))
+  where arrow = blue (pretty "→")
 
 
 -- $setup

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -6,7 +6,6 @@ import           Control.Effect.Carrier
 import           Control.Monad.Module
 import qualified Data.Set as Set
 import           GHC.Generics (Generic1)
-import           Path.Name
 import           Path.Pretty
 import           Path.Scope
 import           Path.Syntax
@@ -75,11 +74,6 @@ pis names body = foldr pi body names
 unpi :: (Alternative m, Member Core sig, RightModule sig) => a -> Term sig a -> m (a ::: Term sig a, Term sig a)
 unpi n (Term t) | Just (Pi t b) <- prj t = pure (n ::: t, instantiate1 (pure n) b)
 unpi _ _                                 = empty
-
-
-generalizeType :: Ord n => Term Core (Name n) -> Term Core Qualified
-generalizeType ty = name undefined id <$> uncurry pis (traverse (traverse f) ty)
-  where f name = (Set.singleton (Local name ::: type'), name)
 
 
 instance Pretty a => Pretty (Term Core a) where

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -159,17 +159,6 @@ logError = tell . (Nil :>)
 type Context = Stack (Name N ::: Term (Problem :+: Core) (Name N))
 
 
-data Binding
-  = Define (Qualified := Term (Problem :+: Core) (Name N))
-  | Exists (N := Maybe (Term (Problem :+: Core) (Name N)))
-  | ForAll N
-  deriving (Eq, Ord, Show)
-
-bindingName :: Binding -> Name N
-bindingName (Define (n := _)) = Global n
-bindingName (Exists (n := _)) = Local n
-bindingName (ForAll  n)       = Local n
-
 lookupBinding :: Qualified -> Context -> Maybe (Name N ::: Term (Problem :+: Core) (Name N))
 lookupBinding n = Stack.find ((== Global n) . typedTerm)
 

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -94,7 +94,7 @@ elab ctx = \case
     Var (B n) -> pure (pure (B n) ::: ctx ! n)
     Var (F n) -> assume n
     Term t -> case t of
-      Surface.Lam _ b -> intro (\ t -> spanIs (elab (VS t (fmap (first FS) <$> ctx)) . fromScopeFin <$> b))
+      Surface.Lam _ b -> intro (\ t -> elab' (VS t (fmap (first FS) <$> ctx)) (fromScopeFin <$> b))
       f Surface.:$ (_ :< a) -> app (elab' ctx f) (elab' ctx a)
       Surface.Type -> pure (type' ::: type')
       Surface.Pi (_ :< _ ::: t) b -> elab' ctx t --> \ t' -> elab' (VS t' (fmap (first FS) <$> ctx)) (fromScopeFin <$> b)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -31,7 +31,7 @@ assume :: ( Carrier sig m
           )
        => Qualified
        -> m (Term (Problem :+: Core) (Name N) ::: Term (Problem :+: Core) (Name N))
-assume v = asks (lookupBinding v) >>= maybe (freeVariables (pure v)) (pure . (Var (Global v) :::) . typedType)
+assume v = asks (Stack.find ((== Global @N v) . typedTerm)) >>= maybe (freeVariables (pure v)) (pure . (Var (Global v) :::) . typedType)
 
 intro :: ( Carrier sig m
          , Member (Reader N) sig
@@ -157,10 +157,6 @@ logError = tell . (Nil :>)
 
 
 type Context = Stack (Name N ::: Term (Problem :+: Core) (Name N))
-
-
-lookupBinding :: Qualified -> Context -> Maybe (Name N ::: Term (Problem :+: Core) (Name N))
-lookupBinding n = Stack.find ((== Global n) . typedTerm)
 
 
 identity, identityT, constant, constantT, constantTQ :: Term (Problem :+: Core) String

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -77,7 +77,7 @@ goalIs ty2 m = do
 meta
   :: Term (Problem :+: Core) (Var (Fin n) a)
   -> Term (Problem :+: Core) (Var (Fin n) a)
-meta ty = Term (L (Ex ty (toScopeFin (pure (B FZ)))))
+meta ty = send (Ex ty (toScopeFin (pure (B FZ))))
 
 
 elab

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -171,11 +171,6 @@ bindingName (Define (n := _)) = Global n
 bindingName (Exists (n := _)) = Local n
 bindingName (ForAll  n)       = Local n
 
-bindingValue :: Binding -> Maybe (Term (Problem :+: Core) (Name N))
-bindingValue (Define (_ := v)) = Just v
-bindingValue (Exists (_ := v)) = v
-bindingValue (ForAll  _)       = Nothing
-
 lookupBinding :: Qualified -> Context -> Maybe (Binding ::: Term (Problem :+: Core) (Name N))
 lookupBinding n = Stack.find ((== Global n) . bindingName . typedTerm)
 

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -13,7 +13,7 @@ import Path.Core
 import Path.Error
 import Path.Module as Module
 import Path.Name
-import Path.Plicity
+import Path.Plicity (Plicit (..))
 import Path.Pretty
 import Path.Problem
 import Path.Scope

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -38,8 +38,8 @@ intro :: Monad m
       => (Term (Problem :+: Core) (Var (Fin ('S n)) a) -> m (Term (Problem :+: Core) (Var (Fin ('S n)) a) ::: Term (Problem :+: Core) (Var (Fin ('S n)) a)))
       -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
 intro body = do
-  _A <- meta type'
-  _B <- meta type'
+  let _A = meta type'
+      _B = meta type'
   u <- goalIs _B (body (first FS <$> _A))
   pure (lamFin u ::: piFin _A _B)
 
@@ -57,9 +57,9 @@ app :: Monad m
     -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
     -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
 app f a = do
-  _A <- meta type'
-  _B <- meta type'
-  let _F = piFin _A _B
+  let _A = meta type'
+      _B = meta type'
+      _F = piFin _A _B
   f' <- goalIs _F f
   a' <- goalIs _A a
   pure (f' $$ a' ::: _F $$ a')
@@ -71,14 +71,13 @@ goalIs :: Monad m
        -> m (Term (Problem :+: Core) (Var (Fin n) a))
 goalIs ty2 m = do
   tm1 ::: ty1 <- m
-  tm2 <- meta (ty1 === ty2)
+  let tm2 = meta (ty1 === ty2)
   pure (tm1 === tm2)
 
 meta
-  :: Monad m
-  => Term (Problem :+: Core) (Var (Fin n) a)
-  -> m (Term (Problem :+: Core) (Var (Fin n) a))
-meta ty = pure (Term (L (Ex ty (toScopeFin (pure (B FZ))))))
+  :: Term (Problem :+: Core) (Var (Fin n) a)
+  -> Term (Problem :+: Core) (Var (Fin n) a)
+meta ty = Term (L (Ex ty (toScopeFin (pure (B FZ)))))
 
 
 elab

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -77,7 +77,7 @@ goalIs ty2 m = do
 meta
   :: Term (Problem :+: Core) (Var (Fin n) a)
   -> Term (Problem :+: Core) (Var (Fin n) a)
-meta ty = send (Ex ty (toScopeFin (pure (B FZ))))
+meta ty = existsFin ty (pure (B FZ))
 
 
 elab

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -34,7 +34,7 @@ assume :: ( Carrier sig m
        -> m (Term (Problem :+: Core) (Var (Fin n) Qualified) ::: Term (Problem :+: Core) (Var (Fin n) Qualified))
 assume v = asks (Stack.find ((== v) . typedTerm)) >>= maybe (freeVariables (pure v)) (pure . (Var (F v) :::) . fmap F . typedType)
 
-intro :: Carrier sig m
+intro :: Monad m
       => (Term (Problem :+: Core) (Var (Fin ('S n)) a) -> m (Term (Problem :+: Core) (Var (Fin ('S n)) a) ::: Term (Problem :+: Core) (Var (Fin ('S n)) a)))
       -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
 intro body = do
@@ -43,7 +43,7 @@ intro body = do
   u <- goalIs _B (body (first FS <$> _A))
   pure (lamFin u ::: piFin _A _B)
 
-(-->) :: Carrier sig m
+(-->) :: Monad m
       => m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
       -> (Term (Problem :+: Core) (Var (Fin ('S n)) a) -> m (Term (Problem :+: Core) (Var (Fin ('S n)) a) ::: Term (Problem :+: Core) (Var (Fin ('S n)) a)))
       -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
@@ -52,7 +52,7 @@ t --> body = do
   b' <- goalIs type' (body (first FS <$> t'))
   pure (piFin t' b' ::: type')
 
-app :: Carrier sig m
+app :: Monad m
     => m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
     -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
     -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
@@ -65,7 +65,7 @@ app f a = do
   pure (f' $$ a' ::: _F $$ a')
 
 
-goalIs :: Carrier sig m
+goalIs :: Monad m
        => Term (Problem :+: Core) (Var (Fin n) a)
        -> m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
        -> m (Term (Problem :+: Core) (Var (Fin n) a))

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -41,7 +41,7 @@ intro body = do
   _A <- meta type'
   _B <- meta type'
   u <- goalIs _B (body (first FS <$> _A))
-  pure (send (Lam (toScopeFin u)) ::: send (Pi _A (toScopeFin _B)))
+  pure (lamFin u ::: piFin _A _B)
 
 (-->) :: Carrier sig m
       => m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
@@ -50,7 +50,7 @@ intro body = do
 t --> body = do
   t' <- goalIs type' t
   b' <- goalIs type' (body (first FS <$> t'))
-  pure (send (Pi t' (toScopeFin b')) ::: type')
+  pure (piFin t' b' ::: type')
 
 app :: Carrier sig m
     => m (Term (Problem :+: Core) (Var (Fin n) a) ::: Term (Problem :+: Core) (Var (Fin n) a))
@@ -59,7 +59,7 @@ app :: Carrier sig m
 app f a = do
   _A <- meta type'
   _B <- meta type'
-  let _F = send (Pi _A (toScopeFin _B))
+  let _F = piFin _A _B
   f' <- goalIs _F f
   a' <- goalIs _A a
   pure (f' $$ a' ::: _F $$ a')

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DeriveFunctor, FlexibleContexts, LambdaCase, TypeApplications, TypeOperators #-}
 module Path.Elab where
 
-import Control.Applicative (liftA2)
 import Control.Effect.Carrier
 import Control.Effect.Error
 import Control.Effect.Reader hiding (Local)
 import Control.Effect.Writer
-import Control.Monad ((<=<), foldM, join)
-import Control.Monad.Trans
+import Control.Monad ((<=<), foldM)
 import Data.Foldable (foldl')
 import qualified Data.Map as Map
 import Data.Void
@@ -180,20 +178,6 @@ bindingValue (ForAll  _)       = Nothing
 
 lookupBinding :: Qualified -> Context -> Maybe (Binding ::: Term (Problem :+: Core) (Name N))
 lookupBinding n = Stack.find ((== Global n) . bindingName . typedTerm)
-
-
-newtype SolverC m a = SolverC { runSolverC :: m (Term Core a) }
-  deriving (Functor)
-
-instance Applicative m => Applicative (SolverC m) where
-  pure = SolverC . pure . Var
-  SolverC f <*> SolverC a = SolverC (liftA2 (<*>) f a)
-
-instance Monad m => Monad (SolverC m) where
-  SolverC a >>= f = SolverC (a >>= fmap join . traverse (runSolverC . f))
-
-instance MonadTrans SolverC where
-  lift = SolverC . fmap Var
 
 
 identity, identityT, constant, constantT, constantTQ :: Term (Problem :+: Core) String

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -99,7 +99,8 @@ elab = go VZ . fmap F
           -> Term Surface.Surface (Var (Fin n) Qualified)
           -> m (Term (Problem :+: Core) (Var (Fin n) Qualified) ::: Term (Problem :+: Core) (Var (Fin n) Qualified))
         go ctx = \case
-          Var v -> var (\ n -> pure (pure (B n) ::: ctx ! n)) assume v
+          Var (B n) -> pure (pure (B n) ::: ctx ! n)
+          Var (F n) -> assume n
           Term t -> case t of
             Surface.Lam _ b -> intro (\ t -> spanIs (go (VS t (fmap (first FS) <$> ctx)) . fromScopeFin <$> b))
             f Surface.:$ (_ :< a) -> app (elab' ctx f) (elab' ctx a)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveFunctor, FlexibleContexts, LambdaCase, TypeApplications, TypeOperators #-}
+{-# LANGUAGE DataKinds, DeriveFunctor, FlexibleContexts, LambdaCase, ScopedTypeVariables, TypeApplications, TypeOperators #-}
 module Path.Elab where
 
 import Control.Effect.Carrier
@@ -81,21 +81,19 @@ meta
 meta ty = pure (Term (L (Ex ty (toScopeFin (pure (B FZ))))))
 
 
-elab :: ( Carrier sig m
-        , Member (Error Doc) sig
-        , Member (Reader Globals) sig
-        , Member (Reader Excerpt) sig
-        )
-     => Term Surface.Surface Qualified
-     -> m (Term (Problem :+: Core) (Var (Fin 'Z) Qualified) ::: Term (Problem :+: Core) (Var (Fin 'Z) Qualified))
+elab
+  :: forall sig m
+  .  ( Carrier sig m
+     , Member (Error Doc) sig
+     , Member (Reader Globals) sig
+     , Member (Reader Excerpt) sig
+     )
+  => Term Surface.Surface Qualified
+  -> m (Term (Problem :+: Core) (Var (Fin 'Z) Qualified) ::: Term (Problem :+: Core) (Var (Fin 'Z) Qualified))
 elab = go VZ . fmap F
   where go
-          :: ( Carrier sig m
-             , Member (Error Doc) sig
-             , Member (Reader Globals) sig
-             , Member (Reader Excerpt) sig
-             )
-          => Vec n (Term (Problem :+: Core) (Var (Fin n) Qualified))
+          :: forall n
+          .  Vec n (Term (Problem :+: Core) (Var (Fin n) Qualified))
           -> Term Surface.Surface (Var (Fin n) Qualified)
           -> m (Term (Problem :+: Core) (Var (Fin n) Qualified) ::: Term (Problem :+: Core) (Var (Fin n) Qualified))
         go ctx = \case

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -31,7 +31,7 @@ assume :: ( Carrier sig m
           )
        => Qualified
        -> m (Term (Problem :+: Core) (Name N) ::: Term (Problem :+: Core) (Name N))
-assume v = asks (Stack.find ((== Global @N v) . typedTerm)) >>= maybe (freeVariables (pure v)) (pure . (Var (Global v) :::) . typedType)
+assume v = asks (Stack.find ((== v) . typedTerm)) >>= maybe (freeVariables (pure v)) (pure . (Var (Global v) :::) . typedType)
 
 intro :: ( Carrier sig m
          , Member (Reader N) sig
@@ -118,7 +118,7 @@ elabDecl :: ( Carrier sig m
 elabDecl (Decl name d tm ty) = runReader (N 0) $ do
   ty' <- runSpanned (goalIs type' . elab) ty
   moduleName <- ask
-  tm' <- runSpanned (local (:> Global @N (moduleName :.: name) ::: unSpanned ty') . goalIs (unSpanned ty') . elab) tm
+  tm' <- runSpanned (local (:> (moduleName :.: name) ::: unSpanned ty') . goalIs (unSpanned ty') . elab) tm
   ty'' <- runSpanned (either freeVariables pure . strengthen) ty'
   tm'' <- runSpanned (either freeVariables pure . strengthen) tm'
   pure (Decl name d tm'' ty'')
@@ -149,14 +149,14 @@ inContext m = do
   runReader @Globals ctx m
   where toContext g = foldl' definitions Nil (modules g)
         definitions ctx m = foldl' define ctx (moduleDecls m)
-          where define ctx d = ctx :> (Global @N (moduleName m :.: declName d) ::: inst (declType d))
+          where define ctx d = ctx :> (moduleName m :.: declName d) ::: inst (declType d)
                 inst t = instantiateEither (pure . Global . either (moduleName m :.:) id) (unSpanned t)
 
 logError :: (Member (Writer (Stack Doc)) sig, Carrier sig m) => Doc -> m ()
 logError = tell . (Nil :>)
 
 
-type Globals = Stack (Name N ::: Term (Problem :+: Core) (Name N))
+type Globals = Stack (Qualified ::: Term (Problem :+: Core) (Name N))
 
 
 identity, identityT, constant, constantT, constantTQ :: Term (Problem :+: Core) String

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -63,17 +63,6 @@ instance Pretty Qualified where
   pretty (m :.: n) = pretty m <> dot <> pretty n
 
 
-data Name a
-  = Global Qualified
-  | Local a
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-instance Pretty a => Pretty (Name a) where
-  pretty = \case
-    Global n -> pretty n
-    Local  n -> pretty n
-
-
 fvs :: (Foldable t, Ord a) => t a -> Set.Set a
 fvs = foldMap Set.singleton
 

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveTraversable, FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeApplications #-}
 module Path.Name where
 
-import           Control.Effect.Reader hiding (Local)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
 import           Path.Pretty
@@ -12,11 +11,6 @@ newtype N = N { unN :: Int }
 
 instance Pretty N where
   pretty (N i) = prettyVar i
-
-bindN :: (Carrier sig m, Member (Reader N) sig) => (N -> m a) -> m a
-bindN f = do
-  n <- ask
-  local @N succ (f n)
 
 
 un :: Monad m => (t -> Maybe (m (a, t))) -> t -> m (Stack a, t)

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -78,10 +78,6 @@ name local _      (Local  n) = local n
 name _     global (Global n) = global n
 
 
-weaken :: Functor f => f Qualified -> f (Name a)
-weaken = fmap Global
-
-
 fvs :: (Foldable t, Ord a) => t a -> Set.Set a
 fvs = foldMap Set.singleton
 

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -73,10 +73,6 @@ instance Pretty a => Pretty (Name a) where
     Global n -> pretty n
     Local  n -> pretty n
 
-name :: (a -> b) -> (Qualified -> b) -> Name a -> b
-name local _      (Local  n) = local n
-name _     global (Global n) = global n
-
 
 fvs :: (Foldable t, Ord a) => t a -> Set.Set a
 fvs = foldMap Set.singleton

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -85,10 +85,6 @@ global :: Applicative m => Qualified -> m (Name a)
 global = pure . Global
 
 
-localNames :: Ord a => Set.Set (Name a) -> Set.Set a
-localNames = foldMap (name Set.singleton (const Set.empty))
-
-
 close :: (Alternative m, Traversable t) => t (Name a) -> m (t Qualified)
 close = traverse (name (const empty) pure)
 

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -1,17 +1,10 @@
-{-# LANGUAGE DeriveTraversable, FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeApplications #-}
+{-# LANGUAGE DeriveTraversable, LambdaCase #-}
 module Path.Name where
 
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
 import           Path.Pretty
 import           Path.Stack
-
-newtype N = N { unN :: Int }
-  deriving (Enum, Eq, Ord, Show)
-
-instance Pretty N where
-  pretty (N i) = prettyVar i
-
 
 un :: Monad m => (t -> Maybe (m (a, t))) -> t -> m (Stack a, t)
 un from = unEither (\ t -> maybe (Left t) Right (from t))

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveTraversable, FlexibleContexts, GeneralizedNewtypeDeriving, LambdaCase, TypeApplications #-}
 module Path.Name where
 
-import           Control.Applicative (Alternative (..))
 import           Control.Effect.Reader hiding (Local)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
@@ -78,10 +77,6 @@ instance Pretty a => Pretty (Name a) where
 name :: (a -> b) -> (Qualified -> b) -> Name a -> b
 name local _      (Local  n) = local n
 name _     global (Global n) = global n
-
-
-close :: (Alternative m, Traversable t) => t (Name a) -> m (t Qualified)
-close = traverse (name (const empty) pure)
 
 
 weaken :: Functor f => f Qualified -> f (Name a)

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -3,13 +3,11 @@ module Path.Name where
 
 import           Control.Applicative (Alternative (..))
 import           Control.Effect.Reader hiding (Local)
-import           Control.Monad.Fail
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
 import           Data.Validation
 import           Path.Pretty
 import           Path.Stack
-import           Prelude hiding (fail)
 
 newtype N = N { unN :: Int }
   deriving (Enum, Eq, Ord, Show)
@@ -84,9 +82,6 @@ name _     global (Global n) = global n
 
 close :: (Alternative m, Traversable t) => t (Name a) -> m (t Qualified)
 close = traverse (name (const empty) pure)
-
-closeFail :: (MonadFail m, Show a, Traversable t) => t (Name a) -> m (t Qualified)
-closeFail = traverse (name (fail . ("free variable: " ++) . show) pure)
 
 
 weaken :: Functor f => f Qualified -> f (Name a)

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -4,7 +4,6 @@ module Path.Name where
 import           Control.Effect.Reader hiding (Local)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
-import           Data.Validation
 import           Path.Pretty
 import           Path.Stack
 
@@ -81,9 +80,6 @@ name _     global (Global n) = global n
 
 weaken :: Functor f => f Qualified -> f (Name a)
 weaken = fmap Global
-
-strengthen :: Traversable t => t (Name n) -> Either (NonEmpty n) (t Qualified)
-strengthen = toEither . traverse (name (Failure . pure) Success)
 
 
 fvs :: (Foldable t, Ord a) => t a -> Set.Set a

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -3,13 +3,11 @@ module Path.Name where
 
 import           Control.Applicative (Alternative (..))
 import           Control.Effect.Reader hiding (Local)
-import           Control.Effect.Writer
 import           Control.Monad.Fail
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
 import           Data.Validation
 import           Path.Pretty
-import           Path.Scope
 import           Path.Stack
 import           Prelude hiding (fail)
 
@@ -23,11 +21,6 @@ bindN :: (Carrier sig m, Member (Reader N) sig) => (N -> m a) -> m a
 bindN f = do
   n <- ask
   local @N succ (f n)
-
-binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> (N -> Doc) -> Scope a f (m Prec) -> m (N, Prec)
-binding go pretty m = bindN $ \ n ->
-  (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (atom (pretty n)))) m)
-
 
 
 un :: Monad m => (t -> Maybe (m (a, t))) -> t -> m (Stack a, t)

--- a/src/Path/Name.hs
+++ b/src/Path/Name.hs
@@ -81,9 +81,6 @@ name :: (a -> b) -> (Qualified -> b) -> Name a -> b
 name local _      (Local  n) = local n
 name _     global (Global n) = global n
 
-global :: Applicative m => Qualified -> m (Name a)
-global = pure . Global
-
 
 close :: (Alternative m, Traversable t) => t (Name a) -> m (t Qualified)
 close = traverse (name (const empty) pure)

--- a/src/Path/Parser/Module.hs
+++ b/src/Path/Parser/Module.hs
@@ -5,7 +5,7 @@ import Control.Applicative (Alternative(..))
 import Control.Effect
 import Control.Monad.IO.Class
 import qualified Path.Module as Module
-import Path.Name hiding (name)
+import Path.Name
 import Path.Parser
 import Path.Parser.Term
 import Path.Pretty (Doc)

--- a/src/Path/Parser/Term.hs
+++ b/src/Path/Parser/Term.hs
@@ -3,7 +3,7 @@ module Path.Parser.Term where
 
 import Control.Applicative (Alternative(..), (<**>))
 import Control.Effect.Reader
-import Path.Name hiding (name)
+import Path.Name
 import Path.Parser as Parser
 import Path.Plicity
 import Path.Span (Spanned(..), unSpanned)

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -12,30 +12,6 @@ import           Path.Syntax
 import           Path.Term
 import           Prelude hiding (pi)
 
-instance Pretty a => Pretty (Term (Problem :+: Core) a) where
-  pretty = prettyTerm (\ go ctx -> \case
-    L p -> prettyProblem go ctx p
-    R c -> prettyCore    go ctx c)
-
-prettyProblem
-  :: Monad f
-  => (forall n . Vec n Doc -> f (Var (Fin n) a) -> Prec)
-  -> Vec n Doc
-  -> Problem f (Var (Fin n) a)
-  -> Prec
-prettyProblem go ctx = \case
-  Ex t b ->
-    let t' = withPrec 1 (go ctx t)
-        n  = prettyMeta (prettyVar (length ctx))
-        b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
-    in prec 0 (magenta (pretty "∃") <+> pretty (n ::: t') </> magenta dot <+> b')
-  p1 :===: p2 ->
-    let p1' = withPrec 1 (go ctx p1)
-        p2' = withPrec 1 (go ctx p2)
-    in prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (space <+> p1' </> eq' <+> p2')))
-  where eq' = magenta (pretty "≡")
-
-
 -- FIXME: represent errors explicitly in the tree
 -- FIXME: represent spans explicitly in the tree
 data Problem f a
@@ -66,3 +42,27 @@ unexists _ _                                 = empty
 p === q = send (p :===: q)
 
 infixr 3 ===
+
+
+instance Pretty a => Pretty (Term (Problem :+: Core) a) where
+  pretty = prettyTerm (\ go ctx -> \case
+    L p -> prettyProblem go ctx p
+    R c -> prettyCore    go ctx c)
+
+prettyProblem
+  :: Monad f
+  => (forall n . Vec n Doc -> f (Var (Fin n) a) -> Prec)
+  -> Vec n Doc
+  -> Problem f (Var (Fin n) a)
+  -> Prec
+prettyProblem go ctx = \case
+  Ex t b ->
+    let t' = withPrec 1 (go ctx t)
+        n  = prettyMeta (prettyVar (length ctx))
+        b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
+    in prec 0 (magenta (pretty "∃") <+> pretty (n ::: t') </> magenta dot <+> b')
+  p1 :===: p2 ->
+    let p1' = withPrec 1 (go ctx p1)
+        p2' = withPrec 1 (go ctx p2)
+    in prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (space <+> p1' </> eq' <+> p2')))
+  where eq' = magenta (pretty "≡")

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE DeriveAnyClass, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Path.Problem where
 
-import           Control.Applicative (Alternative (..))
-import           Control.Effect.Carrier
-import           Control.Monad.Module
-import           GHC.Generics (Generic1)
-import           Path.Core
-import           Path.Pretty
-import           Path.Scope
-import           Path.Syntax
-import           Path.Term
-import           Prelude hiding (pi)
+import Control.Applicative (Alternative (..))
+import Control.Effect.Carrier
+import Control.Monad.Module
+import GHC.Generics (Generic1)
+import Path.Core
+import Path.Pretty
+import Path.Scope
+import Path.Syntax
+import Path.Term
+import Prelude hiding (pi)
 
 -- FIXME: represent errors explicitly in the tree
 -- FIXME: represent spans explicitly in the tree

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, DeriveAnyClass, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Path.Problem where
 
 import Control.Applicative (Alternative (..))
@@ -33,6 +33,9 @@ instance RightModule Problem where
 
 exists :: (Eq a, Carrier sig m, Member Problem sig) => a ::: m a -> m a -> m a
 exists (n ::: t) b = send (Ex t (bind1 n b))
+
+existsFin :: (Carrier sig m, Member Problem sig) => m (Var (Fin n) a) -> m (Var (Fin ('S n)) a) -> m (Var (Fin n) a)
+existsFin t b = send (Ex t (toScopeFin b))
 
 unexists :: (Alternative m, Member Problem sig, RightModule sig) => a -> Term sig a -> m (a ::: Term sig a, Term sig a)
 unexists n (Term t) | Just (Ex t b) <- prj t = pure (n ::: t, instantiate1 (pure n) b)

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -21,17 +21,6 @@ instance Pretty a => Pretty (Term (Problem :+: Core) a) where
     L p -> prettyProblem go p
     R c -> prettyCore    go c)
 
-prettyTerm
-  :: forall a syntax . (Pretty a, RightModule syntax)
-  => (forall f sig m . (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> syntax f (m Prec) -> m Prec)
-  -> Term syntax a
-  -> Doc
-prettyTerm alg = precDoc . snd . run . runWriter @(Set.Set N) . runReader (N 0) . go . fmap (pure . atom . pretty)
-  where go :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig) => Term syntax (m Prec) -> m Prec
-        go = \case
-          Var v -> v
-          Term t -> alg go t
-
 binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> (N -> Doc) -> Scope a f (m Prec) -> m (N, Prec)
 binding go pretty m = bindN $ \ n ->
   (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (atom (pretty n)))) m)

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -45,7 +45,12 @@ binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) si
 binding go pretty m = bindN $ \ n ->
   (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (pretty n))) m)
 
-prettySum :: ((f (m Doc) -> m Doc) -> l f (m Doc) -> m Doc) -> ((f (m Doc) -> m Doc) -> r f (m Doc) -> m Doc) -> (f (m Doc) -> m Doc) -> (l :+: r) f (m Doc) -> m Doc
+prettySum
+  :: ((f (m Doc) -> m Doc) -> l f (m Doc) -> m Doc)
+  -> ((f (m Doc) -> m Doc) -> r f (m Doc) -> m Doc)
+  -> (f (m Doc) -> m Doc)
+  -> (l :+: r) f (m Doc)
+  -> m Doc
 prettySum f g go = \case
   L l -> f go l
   R r -> g go r

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -20,7 +20,7 @@ newtype P = P { unP :: Int }
   deriving (Eq, Ord, Show)
 
 instance Pretty a => Pretty (Term (Problem :+: Core) a) where
-  pretty = prettyTerm (prettySum prettyProblem prettyCore)
+  pretty = prettyTerm (foldSum prettyProblem prettyCore)
 
 prettyTerm
   :: forall a syntax . (Pretty a, RightModule syntax)
@@ -45,13 +45,13 @@ binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) si
 binding go pretty m = bindN $ \ n ->
   (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (pretty n))) m)
 
-prettySum
+foldSum
   :: ((f a -> a) -> l f a -> a)
   -> ((f a -> a) -> r f a -> a)
   -> (f a -> a)
   -> (l :+: r) f a
   -> a
-prettySum f g go = \case
+foldSum f g go = \case
   L l -> f go l
   R r -> g go r
 

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -21,10 +21,6 @@ instance Pretty a => Pretty (Term (Problem :+: Core) a) where
     L p -> prettyProblem go p
     R c -> prettyCore    go c)
 
-binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> (N -> Doc) -> Scope a f (m Prec) -> m (N, Prec)
-binding go pretty m = bindN $ \ n ->
-  (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (atom (pretty n)))) m)
-
 prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Core f (m Prec) -> m Prec
 prettyCore go = \case
   Lam b -> do

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -10,14 +10,11 @@ import qualified Data.Set as Set
 import           GHC.Generics (Generic1)
 import           Path.Core
 import           Path.Name
-import           Path.Pretty hiding (prec, withPrec)
+import           Path.Pretty
 import           Path.Scope
 import           Path.Syntax
 import           Path.Term
 import           Prelude hiding (pi)
-
-newtype P = P { unP :: Int }
-  deriving (Eq, Ord, Show)
 
 instance Pretty a => Pretty (Term (Problem :+: Core) a) where
   pretty = prettyTerm (\ go -> \case
@@ -26,59 +23,51 @@ instance Pretty a => Pretty (Term (Problem :+: Core) a) where
 
 prettyTerm
   :: forall a syntax . (Pretty a, RightModule syntax)
-  => (forall f sig m . (Carrier sig m, Member (Reader N) sig, Member (Reader P) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Doc) -> m Doc) -> syntax f (m Doc) -> m Doc)
+  => (forall f sig m . (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> syntax f (m Prec) -> m Prec)
   -> Term syntax a
   -> Doc
-prettyTerm alg = snd . run . runWriter @(Set.Set N) . runReader (P 0) . runReader (N 0) . go . fmap (pure . pretty)
-  where go :: (Carrier sig m, Member (Reader N) sig, Member (Reader P) sig, Member (Writer (Set.Set N)) sig) => Term syntax (m Doc) -> m Doc
+prettyTerm alg = precDoc . snd . run . runWriter @(Set.Set N) . runReader (N 0) . go . fmap (pure . atom . pretty)
+  where go :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig) => Term syntax (m Prec) -> m Prec
         go = \case
           Var v -> v
           Term t -> alg go t
 
-prec :: (Carrier sig m, Member (Reader P) sig) => Int -> Doc -> m Doc
-prec d' doc = do
-  d <- ask
-  pure (prettyParens (d > P d') doc)
-
-withPrec :: (Carrier sig m, Member (Reader P) sig) => Int -> m a -> m a
-withPrec i = local (const (P i))
-
-binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Doc) -> m Doc) -> (N -> Doc) -> Scope a f (m Doc) -> m (N, Doc)
+binding :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> (N -> Doc) -> Scope a f (m Prec) -> m (N, Prec)
 binding go pretty m = bindN $ \ n ->
-  (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (pretty n))) m)
+  (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (atom (pretty n)))) m)
 
-prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Reader P) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Doc) -> m Doc) -> Core f (m Doc) -> m Doc
+prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Core f (m Prec) -> m Prec
 prettyCore go = \case
   Lam b -> do
-    (n, b') <- withPrec 0 (binding go pretty b)
-    prec 0 (pretty (cyan backslash) <+> pretty n </> cyan dot <+> b')
+    (n, b') <- binding go pretty b
+    pure (prec 0 (pretty (cyan backslash) <+> pretty n </> cyan dot <+> withPrec 0 b'))
   f :$ a -> do
-    f' <- withPrec 10 (go f)
-    a' <- withPrec 11 (go a)
-    prec 10 (f' <+> a')
+    f' <- withPrec 10 <$> go f
+    a' <- withPrec 11 <$> go a
+    pure (prec 10 (f' <+> a'))
   Let v b -> do
-    v' <- withPrec 0 (go v)
-    (n, b') <- withPrec 0 (binding go prettyMeta b)
-    prec 0 (magenta (pretty "let") <+> pretty (n := v') </> magenta dot <+> b')
-  Type -> pure (yellow (pretty "Type"))
+    v' <- withPrec 0 <$> go v
+    (n, b') <- binding go prettyMeta b
+    pure (prec 0 (magenta (pretty "let") <+> pretty (n := v') </> magenta dot <+> withPrec 0 b'))
+  Type -> pure (atom (yellow (pretty "Type")))
   Pi t b -> do
-    t' <- withPrec 1 (go t)
-    (fvs, (n, b')) <- listen (withPrec 0 (binding go pretty b))
+    t' <- withPrec 1 <$> go t
+    (fvs, (n, b')) <- listen (binding go pretty b)
     let t'' | n `Set.member` fvs = parens (pretty (n ::: t'))
             | otherwise          = t'
-    prec 0 (t'' </> arrow <+> b')
+    pure (prec 0 (t'' </> arrow <+> withPrec 0 b'))
   where arrow = blue (pretty "→")
 
-prettyProblem :: (Carrier sig m, Member (Reader N) sig, Member (Reader P) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Doc) -> m Doc) -> Problem f (m Doc) -> m Doc
+prettyProblem :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Problem f (m Prec) -> m Prec
 prettyProblem go = \case
   Ex t b -> do
-    t' <- withPrec 1 (go t)
-    (n, b') <- withPrec 0 (binding go prettyMeta b)
-    prec 0 (magenta (pretty "∃") <+> pretty (n ::: t') </> magenta dot <+> b')
+    t' <- withPrec 1 <$> go t
+    (n, b') <- binding go prettyMeta b
+    pure (prec 0 (magenta (pretty "∃") <+> pretty (n ::: t') </> magenta dot <+> withPrec 0 b'))
   p1 :===: p2 -> do
-    p1' <- withPrec 1 (go p1)
-    p2' <- withPrec 1 (go p2)
-    prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (space <+> p1' </> eq' <+> p2')))
+    p1' <- withPrec 1 <$> go p1
+    p2' <- withPrec 1 <$> go p2
+    pure (prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (space <+> p1' </> eq' <+> p2'))))
   where eq' = magenta (pretty "≡")
 
 

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -21,28 +21,6 @@ instance Pretty a => Pretty (Term (Problem :+: Core) a) where
     L p -> prettyProblem go p
     R c -> prettyCore    go c)
 
-prettyCore :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Core f (m Prec) -> m Prec
-prettyCore go = \case
-  Lam b -> do
-    (n, b') <- binding go pretty b
-    pure (prec 0 (pretty (cyan backslash) <+> pretty n </> cyan dot <+> withPrec 0 b'))
-  f :$ a -> do
-    f' <- withPrec 10 <$> go f
-    a' <- withPrec 11 <$> go a
-    pure (prec 10 (f' <+> a'))
-  Let v b -> do
-    v' <- withPrec 0 <$> go v
-    (n, b') <- binding go prettyMeta b
-    pure (prec 0 (magenta (pretty "let") <+> pretty (n := v') </> magenta dot <+> withPrec 0 b'))
-  Type -> pure (atom (yellow (pretty "Type")))
-  Pi t b -> do
-    t' <- withPrec 1 <$> go t
-    (fvs, (n, b')) <- listen (binding go pretty b)
-    let t'' | n `Set.member` fvs = parens (pretty (n ::: t'))
-            | otherwise          = t'
-    pure (prec 0 (t'' </> arrow <+> withPrec 0 b'))
-  where arrow = blue (pretty "→")
-
 prettyProblem :: (Carrier sig m, Member (Reader N) sig, Member (Writer (Set.Set N)) sig, Monad f) => (f (m Prec) -> m Prec) -> Problem f (m Prec) -> m Prec
 prettyProblem go = \case
   Ex t b -> do

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -46,11 +46,9 @@ binding go pretty m = bindN $ \ n ->
   (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (pretty n))) m)
 
 foldSum
-  :: ((f a -> a) -> l f a -> a)
-  -> ((f a -> a) -> r f a -> a)
-  -> (f a -> a)
-  -> (l :+: r) f a
-  -> a
+  :: ((f a -> a) ->  l        f a -> a)
+  -> ((f a -> a) ->        r  f a -> a)
+  -> ((f a -> a) -> (l :+: r) f a -> a)
 foldSum f g go = \case
   L l -> f go l
   R r -> g go r

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -46,11 +46,11 @@ binding go pretty m = bindN $ \ n ->
   (,) n <$> go (instantiate1 (pure (tell (Set.singleton n) *> pure (pretty n))) m)
 
 prettySum
-  :: ((f (m Doc) -> m Doc) -> l f (m Doc) -> m Doc)
-  -> ((f (m Doc) -> m Doc) -> r f (m Doc) -> m Doc)
-  -> (f (m Doc) -> m Doc)
-  -> (l :+: r) f (m Doc)
-  -> m Doc
+  :: ((f a -> a) -> l f a -> a)
+  -> ((f a -> a) -> r f a -> a)
+  -> (f a -> a)
+  -> (l :+: r) f a
+  -> a
 prettySum f g go = \case
   L l -> f go l
   R r -> g go r

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -135,7 +135,7 @@ script packageSources
           Quit -> throwError ()
           Help -> print helpDoc
           TypeOf tm -> elaborate tm >>= print . pretty . unSpanned
-          Command.Decl decl -> void $ runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= flip renameDecl decl >>= inContext . elabDecl)
+          Command.Decl decl -> void $ runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= flip renameDecl decl >>= withGlobals . elabDecl)
           Eval tm -> elaborate tm >>= gets . flip whnf . unSpanned >>= print . pretty
           ShowModules -> do
             ms <- gets @(ModuleGraph (Term (Problem :+: Core)) Void) (Map.toList . unModuleGraph)
@@ -173,7 +173,7 @@ elaborate :: ( Carrier sig m
           -> m (Spanned (Term (Problem :+: Core) Qualified))
 elaborate = runSpanned $ \ tm -> fmap (var absurdFin id) <$> do
   ty <- meta type'
-  runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= inContext . goalIs ty . elab VZ . fmap F)
+  runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= withGlobals . goalIs ty . elab VZ . fmap F)
 
 -- | Evaluate a term to weak head normal form.
 --

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -19,7 +19,6 @@ import Data.Void
 import GHC.Generics (Generic1)
 import Path.Core
 import Path.Elab
-import Path.Error
 import Path.Module as Module
 import Path.Name
 import Path.Package
@@ -172,10 +171,9 @@ elaborate :: ( Carrier sig m
              )
           => Spanned (Term Surface.Surface User)
           -> m (Spanned (Term (Problem :+: Core) Qualified))
-elaborate = runSpanned $ \ tm -> runReader (N 0) $ do
+elaborate = runSpanned $ \ tm -> fmap (var absurdFin id) <$> do
   ty <- meta type'
-  tm' <- runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= inContext . goalIs ty . elab)
-  either freeVariables pure (strengthen tm')
+  runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= inContext . goalIs ty . elab)
 
 -- | Evaluate a term to weak head normal form.
 --

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -173,7 +173,7 @@ elaborate :: ( Carrier sig m
           -> m (Spanned (Term (Problem :+: Core) Qualified))
 elaborate = runSpanned $ \ tm -> fmap (var absurdFin id) <$> do
   ty <- meta type'
-  runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= inContext . goalIs ty . elab)
+  runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= inContext . goalIs ty . elab VZ . fmap F)
 
 -- | Evaluate a term to weak head normal form.
 --

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -172,7 +172,7 @@ elaborate :: ( Carrier sig m
           => Spanned (Term Surface.Surface User)
           -> m (Spanned (Term (Problem :+: Core) Qualified))
 elaborate = runSpanned $ \ tm -> fmap (var absurdFin id) <$> do
-  ty <- meta type'
+  let ty = meta type'
   runSubgraph (asks @(ModuleGraph (Term (Problem :+: Core)) Void) (fmap unScopeT . unModuleGraph) >>= for tm . rename >>= withGlobals . goalIs ty . elab VZ . fmap F)
 
 -- | Evaluate a term to weak head normal form.

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving #-}
+{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, GADTs, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving #-}
 module Path.Scope where
 
 import Control.Applicative (liftA2)
@@ -43,6 +43,14 @@ incr z s = \case { B a -> z a ; F b -> s b }
 
 data Nat = Z | S Nat
   deriving (Eq, Ord, Show)
+
+data Fin n where
+  FZ :: Fin ('S n)
+  FS :: Fin n -> Fin ('S n)
+
+deriving instance Eq   (Fin n)
+deriving instance Ord  (Fin n)
+deriving instance Show (Fin n)
 
 
 newtype Scope a f b = Scope (f (Var a (f b)))

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -8,6 +8,7 @@ import Control.Monad.Module
 import Control.Monad.Trans (MonadTrans (..))
 import Data.Bifoldable
 import Data.Bifunctor
+import Data.Bitraversable
 import Data.Function (on)
 import Data.List (elemIndex)
 import GHC.Generics (Generic1)
@@ -25,6 +26,11 @@ instance Bifoldable Var where
   bifoldMap f g = \case
     B a -> f a
     F a -> g a
+
+instance Bitraversable Var where
+  bitraverse f g = \case
+    B a -> B <$> f a
+    F a -> F <$> g a
 
 instance Bifunctor Var where
   bimap f g = \case

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -114,8 +114,16 @@ instantiateEither f = unScope >=> incr (f . Left) (>>= f . Right)
 fromScope :: Monad f => Scope a f b -> f (Var a b)
 fromScope = unScope >=> sequenceA
 
+fromScopeFin :: Monad f => Scope () f (Var (Fin n) b) -> f (Var (Fin ('S n)) b)
+fromScopeFin = unScope >=> incr (const (pure (B FZ))) (fmap (first FS))
+
 toScope :: Applicative f => f (Var a b) -> Scope a f b
 toScope = Scope . fmap (fmap pure)
+
+toScopeFin :: Applicative f => f (Var (Fin ('S n)) b) -> Scope () f (Var (Fin n) b)
+toScopeFin = Scope . fmap (match (incr (\case
+  FZ -> Left ()
+  FS n -> Right (B n)) (Right . F)))
 
 
 -- | Like 'Scope', but allows the inner functor to vary. Useful for syntax like declaration scopes, case alternatives, etc., which can bind variables, but cannot (directly) consist solely of them.

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -6,6 +6,7 @@ import Control.Effect.Carrier
 import Control.Monad ((>=>), guard)
 import Control.Monad.Module
 import Control.Monad.Trans (MonadTrans (..))
+import Data.Bifoldable
 import Data.Bifunctor
 import Data.Function (on)
 import Data.List (elemIndex)
@@ -19,6 +20,11 @@ instance (Pretty b, Pretty f) => Pretty (Var b f) where
   pretty = \case
     B b -> pretty b
     F f -> pretty f
+
+instance Bifoldable Var where
+  bifoldMap f g = \case
+    B a -> f a
+    F a -> g a
 
 instance Bifunctor Var where
   bimap f g = \case

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -85,6 +85,11 @@ strengthenFin FZ     = Nothing
 strengthenFin (FS n) = Just n
 
 
+data Vec n a where
+  VZ :: Vec 'Z a
+  VS :: a -> Vec n a -> Vec ('S n) a
+
+
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)
 

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -102,6 +102,8 @@ VS h _ ! FZ   = h
 VS _ t ! FS n = t ! n
 VZ     ! n    = absurdFin n
 
+infixl 9 !
+
 
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -41,6 +41,10 @@ incr :: (a -> c) -> (b -> c) -> Var a b -> c
 incr z s = \case { B a -> z a ; F b -> s b }
 
 
+data Nat = Z | S Nat
+  deriving (Eq, Ord, Show)
+
+
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)
 

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -89,6 +89,11 @@ data Vec n a where
   VZ :: Vec 'Z a
   VS :: a -> Vec n a -> Vec ('S n) a
 
+(!) :: Vec n a -> Fin n -> a
+VS h _ ! FZ   = h
+VS _ t ! FS n = t ! n
+VZ     ! n    = absurdFin n
+
 
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -55,6 +55,10 @@ deriving instance Show (Fin n)
 absurdFin :: Fin 'Z -> a
 absurdFin v = case v of {}
 
+finToInt :: Fin n -> Int
+finToInt FZ     = 0
+finToInt (FS n) = 1 + finToInt n
+
 
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -68,6 +68,10 @@ finToInt :: Fin n -> Int
 finToInt FZ     = 0
 finToInt (FS n) = 1 + finToInt n
 
+strengthenFin :: Fin ('S n) -> Maybe (Fin n)
+strengthenFin FZ     = Nothing
+strengthenFin (FS n) = Just n
+
 
 newtype Scope a f b = Scope (f (Var a (f b)))
   deriving (Foldable, Functor, Generic1, Traversable)

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -93,6 +93,10 @@ deriving instance Eq   a => Eq   (Vec n a)
 deriving instance Ord  a => Ord  (Vec n a)
 deriving instance Show a => Show (Vec n a)
 
+deriving instance Foldable    (Vec n)
+deriving instance Functor     (Vec n)
+deriving instance Traversable (Vec n)
+
 (!) :: Vec n a -> Fin n -> a
 VS h _ ! FZ   = h
 VS _ t ! FS n = t ! n

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -170,9 +170,7 @@ toScope :: Applicative f => f (Var a b) -> Scope a f b
 toScope = Scope . fmap (fmap pure)
 
 toScopeFin :: Applicative f => f (Var (Fin ('S n)) b) -> Scope () f (Var (Fin n) b)
-toScopeFin = Scope . fmap (match (var (\case
-  FZ -> Left ()
-  FS n -> Right (B n)) (Right . F)))
+toScopeFin = Scope . fmap (match (var (maybe (Left ()) (Right . B) . strengthenFin) (Right . F)))
 
 
 -- | Like 'Scope', but allows the inner functor to vary. Useful for syntax like declaration scopes, case alternatives, etc., which can bind variables, but cannot (directly) consist solely of them.

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -10,6 +10,7 @@ import Data.Bifunctor
 import Data.Function (on)
 import Data.List (elemIndex)
 import GHC.Generics (Generic1)
+import Path.Pretty
 
 data Var a b = B a | F b
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
@@ -51,6 +52,9 @@ data Fin n where
 deriving instance Eq   (Fin n)
 deriving instance Ord  (Fin n)
 deriving instance Show (Fin n)
+
+instance Pretty (Fin n) where
+  pretty = prettyVar . finToInt
 
 absurdFin :: Fin 'Z -> a
 absurdFin v = case v of {}

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -15,6 +15,11 @@ import Path.Pretty
 data Var a b = B a | F b
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+instance (Pretty b, Pretty f) => Pretty (Var b f) where
+  pretty = \case
+    B b -> pretty b
+    F f -> pretty f
+
 instance Bifunctor Var where
   bimap f g = \case
     B a -> B (f a)

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -29,6 +29,9 @@ instance Monad (Var a) where
   B e >>= _ = B e
   F a >>= f = f a
 
+incr :: (a -> c) -> (b -> c) -> Var a b -> c
+incr z s = \case { B a -> z a ; F b -> s b }
+
 match :: Applicative f => (b -> Either a c) -> b -> Var a (f c)
 match f x = either B (F . pure) (f x)
 
@@ -37,9 +40,6 @@ matchM f x = either B (F . pure) <$> f x
 
 matchMaybe :: (b -> Maybe a) -> (b -> Either a b)
 matchMaybe f a = maybe (Right a) Left (f a)
-
-incr :: (a -> c) -> (b -> c) -> Var a b -> c
-incr z s = \case { B a -> z a ; F b -> s b }
 
 
 data Nat = Z | S Nat

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -6,12 +6,18 @@ import Control.Effect.Carrier
 import Control.Monad ((>=>), guard)
 import Control.Monad.Module
 import Control.Monad.Trans (MonadTrans (..))
+import Data.Bifunctor
 import Data.Function (on)
 import Data.List (elemIndex)
 import GHC.Generics (Generic1)
 
 data Var a b = B a | F b
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+instance Bifunctor Var where
+  bimap f g = \case
+    B a -> B (f a)
+    F a -> F (g a)
 
 instance Applicative (Var a) where
   pure = F

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, GADTs, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving #-}
+{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, EmptyCase, FlexibleInstances, GADTs, LambdaCase, MultiParamTypeClasses, QuantifiedConstraints, RankNTypes, StandaloneDeriving #-}
 module Path.Scope where
 
 import Control.Applicative (liftA2)
@@ -51,6 +51,9 @@ data Fin n where
 deriving instance Eq   (Fin n)
 deriving instance Ord  (Fin n)
 deriving instance Show (Fin n)
+
+absurdFin :: Fin 'Z -> a
+absurdFin v = case v of {}
 
 
 newtype Scope a f b = Scope (f (Var a (f b)))

--- a/src/Path/Scope.hs
+++ b/src/Path/Scope.hs
@@ -89,6 +89,10 @@ data Vec n a where
   VZ :: Vec 'Z a
   VS :: a -> Vec n a -> Vec ('S n) a
 
+deriving instance Eq   a => Eq   (Vec n a)
+deriving instance Ord  a => Ord  (Vec n a)
+deriving instance Show a => Show (Vec n a)
+
 (!) :: Vec n a -> Fin n -> a
 VS h _ ! FZ   = h
 VS _ t ! FS n = t ! n

--- a/src/Path/Term.hs
+++ b/src/Path/Term.hs
@@ -49,8 +49,17 @@ prettyTerm
   => (forall f n . (Foldable f, Monad f) => (forall n . Vec n Doc -> f (Var (Fin n) a) -> Prec) -> Vec n Doc -> sig f (Var (Fin n) a) -> Prec)
   -> Term sig a
   -> Doc
-prettyTerm alg = precDoc . go VZ . fmap F
-  where go :: Vec n Doc -> Term sig (Var (Fin n) a) -> Prec
+prettyTerm alg = precDoc . prettyTermInContext alg VZ . fmap F
+
+prettyTermInContext
+  :: forall sig n a
+  .  (forall g . Foldable g => Foldable (sig g), Pretty a, RightModule sig)
+  => (forall f n . (Foldable f, Monad f) => (forall n . Vec n Doc -> f (Var (Fin n) a) -> Prec) -> Vec n Doc -> sig f (Var (Fin n) a) -> Prec)
+  -> Vec n Doc
+  -> Term sig (Var (Fin n) a)
+  -> Prec
+prettyTermInContext alg = go
+  where go :: forall n . Vec n Doc -> Term sig (Var (Fin n) a) -> Prec
         go ctx = \case
           Var v -> atom (var (pretty . (ctx !)) pretty v)
           Term t -> alg go ctx t


### PR DESCRIPTION
This PR:

- Introduces `Fin` and some machinery to bind/instantiate scopes with finite sets of variables.
- Uses `Fin` for pretty-printing & elaboration.
- Defines pretty-printing for `Term Core`.
- 🔥s `N`.
- 🔥s `Name`.