### PR TITLE
Prettyprinter

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -42,8 +42,7 @@ library
                      , Path.Usage
   other-modules:       Paths_path
   -- other-extensions:
-  build-depends:       ansi-wl-pprint
-                     , base >=4.11 && <4.13
+  build-depends:       base >=4.11 && <4.13
                      , bytestring
                      , containers
                      , directory
@@ -53,6 +52,8 @@ library
                      , mtl
                      , optparse-applicative
                      , parsers
+                     , prettyprinter
+                     , prettyprinter-ansi-terminal
                      , terminal-size
                      , text
                      , unordered-containers

--- a/src/Path/CLI.hs
+++ b/src/Path/CLI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module Path.CLI where
 
 import Control.Effect.Error (runError)
@@ -25,7 +24,7 @@ argumentsParser = info
 
 options :: Parser (IO ())
 options
-  =   flag' (either (prettyPrint @Notice) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
+  =   flag' (either (putDoc . prettyNotice) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
   <*> (pure . Right <$> some source <|> parsePackage <$> strOption (long "package-path" <> metavar "FILE" <> help "source file"))
   where parsePackage = fmap (fmap packageSources) . runM . runError . parseFile (whole Parser.package)
 

--- a/src/Path/CLI.hs
+++ b/src/Path/CLI.hs
@@ -25,7 +25,7 @@ argumentsParser = info
 
 options :: Parser (IO ())
 options
-  =   flag' (either (prettyPrint @Doc) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
+  =   flag' (either (prettyPrint @Notice) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
   <*> (pure . Right <$> some source <|> parsePackage <$> strOption (long "package-path" <> metavar "FILE" <> help "source file"))
   where parsePackage = fmap (fmap packageSources) . runM . runError . parseFile (whole Parser.package)
 

--- a/src/Path/CLI.hs
+++ b/src/Path/CLI.hs
@@ -6,6 +6,7 @@ import Control.Effect.Lift (runM)
 import Control.Monad (join)
 import Data.Version (showVersion)
 import Options.Applicative as Options
+import Path.Error
 import Path.Package
 import Path.Parser (parseFile, whole)
 import Path.Parser.Package as Parser (package)

--- a/src/Path/CLI.hs
+++ b/src/Path/CLI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module Path.CLI where
 
 import Control.Effect.Error (runError)
@@ -24,7 +25,7 @@ argumentsParser = info
 
 options :: Parser (IO ())
 options
-  =   flag' (either (putDoc . prettyNotice) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
+  =   flag' (either (prettyPrint @Notice) repl =<<) (short 'i' <> long "interactive" <> help "run interactively")
   <*> (pure . Right <$> some source <|> parsePackage <$> strOption (long "package-path" <> metavar "FILE" <> help "source file"))
   where parsePackage = fmap (fmap packageSources) . runM . runError . parseFile (whole Parser.package)
 

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -89,7 +89,7 @@ prettyCore go ctx = \case
   Lam b ->
     let n  = prettyVar (length ctx)
         b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
-    in prec 0 (pretty (cyan backslash) <+> n </> cyan dot <+> b')
+    in prec 0 (group (vsep [pretty (cyan backslash) <+> n, cyan dot <+> b']))
   f :$ a ->
     let f' = withPrec 10 (go ctx f)
         a' = withPrec 11 (go ctx a)
@@ -98,7 +98,7 @@ prettyCore go ctx = \case
     let v' = withPrec 0 (go ctx v)
         n  = prettyVar (length ctx)
         b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
-    in prec 0 (magenta (pretty "let") <+> pretty (n := v') </> magenta dot <+> b')
+    in prec 0 (group (vsep [magenta (pretty "let") <+> pretty (n := v'), magenta dot <+> b']))
   Type -> atom (yellow (pretty "Type"))
   Pi t b ->
     let t'  = withPrec 1 (go ctx t)
@@ -108,7 +108,7 @@ prettyCore go ctx = \case
         b'' = withPrec 0 (go (VS n ctx) b')
         t'' | FZ `Set.member` fvs = parens (pretty (n ::: t'))
             | otherwise           = t'
-    in prec 0 (t'' </> arrow <+> b'')
+    in prec 0 (group (vsep [t'', arrow <+> b'']))
   where arrow = blue (pretty "→")
 
 

--- a/src/Path/Core.hs
+++ b/src/Path/Core.hs
@@ -89,7 +89,7 @@ prettyCore go ctx = \case
   Lam b ->
     let n  = prettyVar (length ctx)
         b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
-    in prec 0 (group (vsep [pretty (cyan backslash) <+> n, cyan dot <+> b']))
+    in prec 0 (group (vsep [cyan backslash <+> n, cyan dot <+> b']))
   f :$ a ->
     let f' = withPrec 10 (go ctx f)
         a' = withPrec 11 (go ctx a)

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -15,7 +15,6 @@ import Path.Error
 import Path.Module as Module
 import Path.Name
 import Path.Plicity (Plicit (..))
-import Path.Pretty
 import Path.Problem
 import Path.Scope
 import Path.Span

--- a/src/Path/Elab.hs
+++ b/src/Path/Elab.hs
@@ -26,7 +26,7 @@ import Path.Term
 import Prelude hiding (pi)
 
 assume :: ( Carrier sig m
-          , Member (Error Doc) sig
+          , Member (Error Notice) sig
           , Member (Reader Globals) sig
           , Member (Reader Excerpt) sig
           )
@@ -82,7 +82,7 @@ meta ty = existsFin ty (pure (B FZ))
 
 elab
   :: ( Carrier sig m
-     , Member (Error Doc) sig
+     , Member (Error Notice) sig
      , Member (Reader Globals) sig
      , Member (Reader Excerpt) sig
      )
@@ -100,7 +100,7 @@ elab ctx = \case
   where elab' ctx m = spanIs (elab ctx <$> m)
 
 elabDecl :: ( Carrier sig m
-            , Member (Error Doc) sig
+            , Member (Error Notice) sig
             , Member (Reader Globals) sig
             , Member (Reader ModuleName) sig
             )
@@ -115,9 +115,9 @@ elabDecl (Decl name d tm ty) = do
         strengthen = fmap (var absurdFin id)
 
 elabModule :: ( Carrier sig m
-              , Member (Error Doc) sig
+              , Member (Error Notice) sig
               , Member (Reader (ModuleGraph (Term (Problem :+: Core)) Void)) sig
-              , Member (Writer (Stack Doc)) sig
+              , Member (Writer (Stack Notice)) sig
               )
            => Module (Term Surface.Surface) Qualified
            -> m (Module (Term (Problem :+: Core)) Qualified)
@@ -144,7 +144,7 @@ withGlobals m = do
           where define ctx d = ctx :> (moduleName m :.: declName d) ::: inst (declType d)
                 inst t = instantiateEither (pure . either (moduleName m :.:) id) (unSpanned t)
 
-logError :: (Member (Writer (Stack Doc)) sig, Carrier sig m) => Doc -> m ()
+logError :: (Member (Writer (Stack Notice)) sig, Carrier sig m) => Notice -> m ()
 logError = tell . (Nil :>)
 
 

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -29,4 +29,4 @@ unknownModule (name :~ excerpt) = throwError (Notice (Just Error) excerpt (prett
 cyclicImport :: (Carrier sig m, Member (Error Notice) sig) => NonEmpty (Spanned ModuleName) -> m a
 cyclicImport (name :~ span :| [])    = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name)) [])
 cyclicImport (name :~ span :| names) = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) (foldr ((:) . whichImports) [ whichImports (name :~ span) ] names))
-  where whichImports (name :~ excerpt) = pretty (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])
+  where whichImports (name :~ excerpt) = prettyNotice (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -10,23 +10,23 @@ import Path.Name
 import Path.Pretty
 import Path.Span
 
-freeVariables :: (Carrier sig m, Member (Error Doc) sig, Member (Reader Excerpt) sig, Ord name, Pretty name) => NonEmpty name -> m a
+freeVariables :: (Carrier sig m, Member (Error Notice) sig, Member (Reader Excerpt) sig, Ord name, Pretty name) => NonEmpty name -> m a
 freeVariables names = do
   span <- ask
-  throwError (pretty (Notice (Just Error) span (pretty "free variable" <> (if length names == 1 then mempty else pretty "s") <+> fillSep (punctuate comma (map pretty (toList (foldMap Set.singleton names))))) []))
+  throwError (Notice (Just Error) span (pretty "free variable" <> (if length names == 1 then mempty else pretty "s") <+> fillSep (punctuate comma (map pretty (toList (foldMap Set.singleton names))))) [])
 
-ambiguousName :: (Carrier sig m, Member (Error Doc) sig, Member (Reader Excerpt) sig) => User -> NonEmpty Qualified -> m a
+ambiguousName :: (Carrier sig m, Member (Error Notice) sig, Member (Reader Excerpt) sig) => User -> NonEmpty Qualified -> m a
 ambiguousName name sources = do
   span <- ask
-  throwError . pretty $ Notice (Just Error) span (pretty "ambiguous name" <+> squotes (pretty name)) [nest 2 (vsep
+  throwError $ Notice (Just Error) span (pretty "ambiguous name" <+> squotes (pretty name)) [nest 2 (vsep
     ( pretty "it could refer to"
     : map pretty (toList sources)))]
 
 
-unknownModule :: (Carrier sig m, Member (Error Doc) sig) => Spanned ModuleName -> m a
-unknownModule (name :~ excerpt) = throwError (pretty (Notice (Just Error) excerpt (pretty "Could not find module" <+> squotes (pretty name)) []))
+unknownModule :: (Carrier sig m, Member (Error Notice) sig) => Spanned ModuleName -> m a
+unknownModule (name :~ excerpt) = throwError (Notice (Just Error) excerpt (pretty "Could not find module" <+> squotes (pretty name)) [])
 
-cyclicImport :: (Carrier sig m, Member (Error Doc) sig) => NonEmpty (Spanned ModuleName) -> m a
-cyclicImport (name :~ span :| [])    = throwError (pretty (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name)) []))
-cyclicImport (name :~ span :| names) = throwError (pretty (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) (foldr ((:) . whichImports) [ whichImports (name :~ span) ] names)))
+cyclicImport :: (Carrier sig m, Member (Error Notice) sig) => NonEmpty (Spanned ModuleName) -> m a
+cyclicImport (name :~ span :| [])    = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name)) [])
+cyclicImport (name :~ span :| names) = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) (foldr ((:) . whichImports) [ whichImports (name :~ span) ] names))
   where whichImports (name :~ excerpt) = pretty (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -29,4 +29,4 @@ unknownModule (name :~ excerpt) = throwError (Notice (Just Error) excerpt (prett
 cyclicImport :: (Carrier sig m, Member (Error Notice) sig) => NonEmpty (Spanned ModuleName) -> m a
 cyclicImport (name :~ span :| [])    = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name)) [])
 cyclicImport (name :~ span :| names) = throwError (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) (foldr ((:) . whichImports) [ whichImports (name :~ span) ] names))
-  where whichImports (name :~ excerpt) = prettyNotice (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])
+  where whichImports (name :~ excerpt) = pretty (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -3,12 +3,42 @@ module Path.Error where
 
 import Control.Effect.Error
 import Control.Effect.Reader
-import Data.Foldable (toList)
+import Data.Foldable (fold, toList)
+import Data.List (isSuffixOf)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Set as Set
 import Path.Name
 import Path.Pretty
 import Path.Span
+
+data Level
+  = Warn
+  | Error
+  deriving (Eq, Ord, Show)
+
+instance Pretty Level where
+  pretty Warn  = magenta (pretty "warning")
+  pretty Error = red (pretty "error")
+
+
+data Notice = Notice
+  { noticeLevel   :: Maybe Level
+  , noticeExcerpt :: {-# UNPACK #-} !Excerpt
+  , noticeReason  :: Doc
+  , noticeContext :: [Doc]
+  }
+  deriving (Show)
+
+instance Pretty Notice where
+  pretty (Notice level (Excerpt path line span) reason context) = vsep
+    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, reason]))
+    : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
+      [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
+      , blue (pretty '|') <+> caret span
+      ])
+    : context)
+    where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
+
 
 freeVariables :: (Carrier sig m, Member (Error Notice) sig, Member (Reader Excerpt) sig, Ord name, Pretty name) => NonEmpty name -> m a
 freeVariables names = do

--- a/src/Path/Error.hs
+++ b/src/Path/Error.hs
@@ -28,7 +28,5 @@ unknownModule (name :~ excerpt) = throwError (pretty (Notice (Just Error) excerp
 
 cyclicImport :: (Carrier sig m, Member (Error Doc) sig) => NonEmpty (Spanned ModuleName) -> m a
 cyclicImport (name :~ span :| [])    = throwError (pretty (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name)) []))
-cyclicImport (name :~ span :| names) = throwError (vsep
-  ( pretty (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) [])
-  : foldr ((:) . whichImports) [ whichImports (name :~ span) ] names))
+cyclicImport (name :~ span :| names) = throwError (pretty (Notice (Just Error) span (pretty "Cyclic import of" <+> squotes (pretty name) <> colon) (foldr ((:) . whichImports) [ whichImports (name :~ span) ] names)))
   where whichImports (name :~ excerpt) = pretty (Notice Nothing excerpt (pretty "which imports" <+> squotes (pretty name) <> colon) [])

--- a/src/Path/Module.hs
+++ b/src/Path/Module.hs
@@ -18,7 +18,6 @@ import Data.Void
 import GHC.Generics (Generic1)
 import Path.Error
 import Path.Name
-import Path.Pretty
 import Path.Scope
 import Path.Span
 

--- a/src/Path/Module.hs
+++ b/src/Path/Module.hs
@@ -75,7 +75,7 @@ moduleGraph ms = ModuleGraph (Map.fromList (map ((,) . moduleName <*> bindTEithe
 restrict :: Set.Set ModuleName -> ModuleGraph f a -> ModuleGraph f a
 restrict keys = ModuleGraph . flip Map.restrictKeys keys . unModuleGraph
 
-rename :: (Carrier sig m, Foldable t, Member (Error Doc) sig, Member (Reader Excerpt) sig)
+rename :: (Carrier sig m, Foldable t, Member (Error Notice) sig, Member (Reader Excerpt) sig)
        => t (Module f a)
        -> User
        -> m Qualified
@@ -90,13 +90,13 @@ runDecl f (Decl n d tm ty) = do
   ty' <- runSpanned f ty
   pure (Decl n d tm' ty')
 
-renameDecl :: (Carrier sig m, Foldable t, Member (Error Doc) sig, Traversable g)
+renameDecl :: (Carrier sig m, Foldable t, Member (Error Notice) sig, Traversable g)
            => t (Module f a)
            -> Decl (g User)
            -> m (Decl (g Qualified))
 renameDecl ms = runDecl (traverse (rename ms))
 
-renameModule :: (Carrier sig m, Foldable t, Member (Error Doc) sig, Traversable g)
+renameModule :: (Carrier sig m, Foldable t, Member (Error Notice) sig, Traversable g)
              => t (Module f a)
              -> Module g User
              -> m (Module g Qualified)
@@ -104,7 +104,7 @@ renameModule ms m = do
   ds <- traverse (runDecl (traverse (rename ms))) (moduleDecls m)
   pure m { moduleDecls = ds }
 
-renameModuleGraph :: (Applicative f, Carrier sig m, Member (Error Doc) sig, Traversable f) => [Module f User] -> m (ModuleGraph f Void)
+renameModuleGraph :: (Applicative f, Carrier sig m, Member (Error Notice) sig, Traversable f) => [Module f User] -> m (ModuleGraph f Void)
 renameModuleGraph ms = do
   ms' <- traverse (\ m -> renameModule (imported m) m) ms
   pure (ModuleGraph (Map.fromList (map ((,) . moduleName <*> bindTEither Left) ms')))
@@ -122,10 +122,10 @@ lookup (mn :.: n) (ModuleGraph g) = do
   pure (instantiate (pure . (moduleName m :.:)) <$> decl)
 
 
-lookupModule :: (Carrier sig m, Member (Error Doc) sig) => Spanned ModuleName -> ModuleGraph f a -> m (ScopeT Qualified Module f a)
+lookupModule :: (Carrier sig m, Member (Error Notice) sig) => Spanned ModuleName -> ModuleGraph f a -> m (ScopeT Qualified Module f a)
 lookupModule i g = maybe (unknownModule i) pure (Map.lookup (unSpanned i) (unModuleGraph g))
 
-cycleFrom :: (Carrier sig m, Effect sig, Member (Error Doc) sig) => ModuleGraph f a -> Spanned ModuleName -> m ()
+cycleFrom :: (Carrier sig m, Effect sig, Member (Error Notice) sig) => ModuleGraph f a -> Spanned ModuleName -> m ()
 cycleFrom g m = runReader (Set.empty :: Set.Set ModuleName) (runNonDetOnce (go m)) >>= cyclicImport . fromMaybe (m :| [])
   where go n = do
           notVisited <- asks (Set.notMember (unSpanned n))
@@ -136,7 +136,7 @@ cycleFrom g m = runReader (Set.empty :: Set.Set ModuleName) (runNonDetOnce (go m
             pure (n :| [])
 
 
-loadOrder :: (Carrier sig m, Effect sig, Member (Error Doc) sig) => ModuleGraph f Void -> m [ScopeT Qualified Module f Void]
+loadOrder :: (Carrier sig m, Effect sig, Member (Error Notice) sig) => ModuleGraph f Void -> m [ScopeT Qualified Module f Void]
 loadOrder g = reverse <$> execState [] (evalState (Set.empty :: Set.Set ModuleName) (runReader (Set.empty :: Set.Set ModuleName) (for_ (unModuleGraph g) loopM)))
   where loopM m = do
           visited <- gets (Set.member (moduleName (unScopeT m)))

--- a/src/Path/Parser.hs
+++ b/src/Path/Parser.hs
@@ -21,7 +21,8 @@ import Control.Monad (MonadPlus(..), ap)
 import Control.Monad.IO.Class
 import qualified Data.HashSet as HashSet
 import Data.Maybe (fromMaybe)
-import Path.Pretty (Doc, Level(..), Notice(..), pretty)
+import Path.Error (Level(..), Notice(..))
+import Path.Pretty (Doc, pretty)
 import Path.Span hiding (spanned)
 import Text.Parser.Char
 import Text.Parser.Combinators

--- a/src/Path/Parser.hs
+++ b/src/Path/Parser.hs
@@ -102,13 +102,13 @@ runParser path pos input m = runReader inputLines (runReader path (runParserC m 
         takeLine ('\n':rest) = ("\n", rest)
         takeLine (c   :rest) = let (cs, rest') = takeLine rest in (c:cs, rest')
 
-parseString :: (Carrier sig m, Member (Error Doc) sig) => ParserC (ReaderC FilePath (ReaderC [String] m)) a -> Pos -> String -> m a
-parseString p pos input = runParser "(interactive)" pos input p >>= either (throwError . pretty) pure
+parseString :: (Carrier sig m, Member (Error Notice) sig) => ParserC (ReaderC FilePath (ReaderC [String] m)) a -> Pos -> String -> m a
+parseString p pos input = runParser "(interactive)" pos input p >>= either throwError pure
 
-parseFile :: (Carrier sig m, Member (Error Doc) sig, MonadIO m) => ParserC (ReaderC FilePath (ReaderC [String] m)) a -> FilePath -> m a
+parseFile :: (Carrier sig m, Member (Error Notice) sig, MonadIO m) => ParserC (ReaderC FilePath (ReaderC [String] m)) a -> FilePath -> m a
 parseFile p path = do
   input <- liftIO (readFile path)
-  runParser path (Pos 0 0) input p >>= either (throwError . pretty) pure
+  runParser path (Pos 0 0) input p >>= either throwError pure
 
 newtype ParserC m a = ParserC
   { runParserC

--- a/src/Path/Parser/Module.hs
+++ b/src/Path/Parser/Module.hs
@@ -4,11 +4,11 @@ module Path.Parser.Module where
 import Control.Applicative (Alternative(..))
 import Control.Effect
 import Control.Monad.IO.Class
+import Path.Error (Notice)
 import qualified Path.Module as Module
 import Path.Name
 import Path.Parser
 import Path.Parser.Term
-import Path.Pretty (Notice)
 import Path.Span (Spanned(..))
 import Path.Surface
 import Path.Term

--- a/src/Path/Parser/Module.hs
+++ b/src/Path/Parser/Module.hs
@@ -8,7 +8,7 @@ import qualified Path.Module as Module
 import Path.Name
 import Path.Parser
 import Path.Parser.Term
-import Path.Pretty (Doc)
+import Path.Pretty (Notice)
 import Path.Span (Spanned(..))
 import Path.Surface
 import Path.Term
@@ -16,7 +16,7 @@ import Text.Parser.Char
 import Text.Parser.Combinators
 import Text.Parser.Token
 
-parseModule :: (Carrier sig m, Effect sig, Member (Error Doc) sig, MonadIO m) => FilePath -> m (Module.Module (Term Surface) User)
+parseModule :: (Carrier sig m, Effect sig, Member (Error Notice) sig, MonadIO m) => FilePath -> m (Module.Module (Term Surface) User)
 parseModule path = parseFile (whole (module' path)) path
 
 

--- a/src/Path/Plicity.hs
+++ b/src/Path/Plicity.hs
@@ -41,4 +41,4 @@ data Plicit a
 infixr 6 :<
 
 instance Pretty a => Pretty (Plicit a) where
-  pretty = prettyPlicity True . fmap pretty
+  pretty = prettyPlicity True

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -9,7 +9,6 @@ module Path.Pretty
 , putDoc
 -- * Errors
 , Level(..)
-, prettyLevel
 , Notice(..)
 , prettyNotice
 -- * Combinators
@@ -88,9 +87,9 @@ data Level
   | Error
   deriving (Eq, Ord, Show)
 
-prettyLevel :: Level -> Doc
-prettyLevel Warn  = magenta (pretty "warning")
-prettyLevel Error = red (pretty "error")
+instance Pretty Level where
+  pretty Warn  = magenta (pretty "warning")
+  pretty Error = red (pretty "error")
 
 
 data Notice = Notice
@@ -103,7 +102,7 @@ data Notice = Notice
 
 prettyNotice :: Notice -> Doc
 prettyNotice (Notice level (Excerpt path line span) reason context) = vsep
-  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, reason]))
+  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, reason]))
   : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
     [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
     , blue (pretty '|') <+> caret span

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -60,7 +60,7 @@ instance Pretty Notice where
       , blue (pretty '|') <+> caret span
       ])
     : context)
-    where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> pretty span
+    where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
 
 
 prettyVar :: Int -> Doc

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -89,7 +89,7 @@ prettySpan (Span start end)
 tabulate2 :: (Pretty a, Pretty b) => Doc -> [(a, b)] -> Doc
 tabulate2 _ [] = mempty
 tabulate2 s cs = vsep (map (uncurry entry) cs')
-  where entry a b = fill w (pretty a) <> s <> pretty b
+  where entry a b = fill w (pretty a) <> s <> b
         w = maximum (map (columnWidth . fst) cs')
         cs' = map (column *** pretty) cs
 

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -5,7 +5,9 @@ module Path.Pretty
 , putDoc
 -- * Errors
 , Level(..)
+, prettyLevel
 , Notice(..)
+, prettyNotice
 -- * Combinators
 , prettyVar
 , prettyMeta
@@ -59,15 +61,15 @@ data Notice = Notice
   }
   deriving (Show)
 
-instance Pretty Notice where
-  pretty (Notice level (Excerpt path line span) reason context) = vsep
-    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, pretty reason]))
-    : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
-      [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
-      , blue (pretty '|') <+> caret span
-      ])
-    : context)
-    where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
+prettyNotice :: Notice -> Doc
+prettyNotice (Notice level (Excerpt path line span) reason context) = vsep
+  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, pretty reason]))
+  : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
+    [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
+    , blue (pretty '|') <+> caret span
+    ])
+  : context)
+  where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
 
 
 prettyVar :: Int -> Doc

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -10,7 +10,6 @@ module Path.Pretty
 -- * Errors
 , Level(..)
 , Notice(..)
-, prettyNotice
 -- * Combinators
 , prettyVar
 , prettyMeta
@@ -100,15 +99,15 @@ data Notice = Notice
   }
   deriving (Show)
 
-prettyNotice :: Notice -> Doc
-prettyNotice (Notice level (Excerpt path line span) reason context) = vsep
-  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, reason]))
-  : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
-    [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
-    , blue (pretty '|') <+> caret span
-    ])
-  : context)
-  where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
+instance Pretty Notice where
+  pretty (Notice level (Excerpt path line span) reason context) = vsep
+    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, reason]))
+    : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
+      [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
+      , blue (pretty '|') <+> caret span
+      ])
+    : context)
+    where caret span = pretty (replicate (posColumn (spanStart span)) ' ') <> prettySpan span
 
 
 prettyVar :: Int -> Doc

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -5,6 +5,7 @@ module Path.Pretty
 , Notice(..)
 , prettyVar
 , prettyMeta
+, prettySpan
 , prettyParens
 , prettyBraces
 , tabulate2
@@ -70,6 +71,13 @@ prettyVar i = pretty (alphabet !! r : if q > 0 then show q else "")
 
 prettyMeta :: Pretty a => a -> Doc
 prettyMeta n = dullblack (bold (pretty '?' <> pretty n))
+
+
+prettySpan :: Span -> Doc
+prettySpan (Span start end)
+  | start == end                 = green (pretty '^')
+  | posLine start == posLine end = green (pretty (replicate (posColumn end - posColumn start) '~'))
+  | otherwise                    = green (pretty "^…")
 
 
 tabulate2 :: (Pretty a, Pretty b) => Doc -> [(a, b)] -> Doc

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -61,7 +61,7 @@ data Notice = Notice
 
 instance Pretty Notice where
   pretty (Notice level (Excerpt path line span) reason context) = vsep
-    ( nest 2 (group (bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level </> pretty reason))
+    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, pretty reason]))
     : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
       [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
       , blue (pretty '|') <+> caret span

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -1,15 +1,21 @@
 module Path.Pretty
-( prettyPrint
+(
+-- * Output
+  prettyPrint
 , putDoc
+-- * Errors
 , Level(..)
 , Notice(..)
+-- * Combinators
 , prettyVar
 , prettyMeta
 , prettySpan
 , tabulate2
 , prettyParens
 , prettyBraces
+-- * Debugging
 , tracePrettyM
+-- * Pretty-printing with precedence
 , Prec(..)
 , prec
 , atom

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -46,9 +46,9 @@ data Level
   | Error
   deriving (Eq, Ord, Show)
 
-instance Pretty Level where
-  pretty Warn  = magenta (pretty "warning")
-  pretty Error = red (pretty "error")
+prettyLevel :: Level -> Doc
+prettyLevel Warn  = magenta (pretty "warning")
+prettyLevel Error = red (pretty "error")
 
 
 data Notice = Notice
@@ -61,7 +61,7 @@ data Notice = Notice
 
 instance Pretty Notice where
   pretty (Notice level (Excerpt path line span) reason context) = vsep
-    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . pretty) level, pretty reason]))
+    ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, pretty reason]))
     : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
       [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
       , blue (pretty '|') <+> caret span

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -6,9 +6,9 @@ module Path.Pretty
 , prettyVar
 , prettyMeta
 , prettySpan
+, tabulate2
 , prettyParens
 , prettyBraces
-, tabulate2
 , tracePrettyM
 , Prec(..)
 , prec

--- a/src/Path/Pretty.hs
+++ b/src/Path/Pretty.hs
@@ -63,7 +63,7 @@ data Notice = Notice
 
 prettyNotice :: Notice -> Doc
 prettyNotice (Notice level (Excerpt path line span) reason context) = vsep
-  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, pretty reason]))
+  ( nest 2 (group (vsep [bold (pretty path) <> colon <> bold (pretty (succ (posLine (spanStart span)))) <> colon <> bold (pretty (succ (posColumn (spanStart span)))) <> colon <> maybe mempty ((space <>) . (<> colon) . prettyLevel) level, reason]))
   : blue (pretty (succ (posLine (spanStart span)))) <+> align (fold
     [ blue (pretty '|') <+> pretty line <> if "\n" `isSuffixOf` line then mempty else blue (pretty "<EOF>") <> hardline
     , blue (pretty '|') <+> caret span

--- a/src/Path/Problem.hs
+++ b/src/Path/Problem.hs
@@ -63,9 +63,9 @@ prettyProblem go ctx = \case
     let t' = withPrec 1 (go ctx t)
         n  = prettyMeta (prettyVar (length ctx))
         b' = withPrec 0 (go (VS n ctx) (fromScopeFin b))
-    in prec 0 (magenta (pretty "∃") <+> pretty (n ::: t') </> magenta dot <+> b')
+    in prec 0 (group (vsep [magenta (pretty "∃") <+> pretty (n ::: t'), magenta dot <+> b']))
   p1 :===: p2 ->
     let p1' = withPrec 1 (go ctx p1)
         p2' = withPrec 1 (go ctx p2)
-    in prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (space <+> p1' </> eq' <+> p2')))
+    in prec 0 (flatAlt (p1' <+> eq' <+> p2') (align (group (vsep [space <+> p1', eq' <+> p2']))))
   where eq' = magenta (pretty "≡")

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -19,6 +19,7 @@ import Data.Void
 import GHC.Generics (Generic1)
 import Path.Core
 import Path.Elab
+import Path.Error
 import Path.Module as Module
 import Path.Name
 import Path.Package

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -126,8 +126,8 @@ script packageSources
   . runReader (ModuleName "(interpreter)")
   . fmap (either id id)
   . runError @()
-  $ runError loop >>= either (print . prettyNotice) pure
-  where loop = (prompt "λ: " >>= parseCommand >>= maybe (pure ()) runCommand . join) `catchError` (print . prettyNotice) >> loop
+  $ runError loop >>= either (print . pretty @Notice) pure
+  where loop = (prompt "λ: " >>= parseCommand >>= maybe (pure ()) runCommand . join) `catchError` (print . pretty @Notice) >> loop
         parseCommand str = do
           l <- askLine
           traverse (parseString (whole command) (linePos l)) str
@@ -160,7 +160,7 @@ script packageSources
           if Prelude.null errs then
             pure (ModuleGraph (Map.insert name (bindTEither Left res) (unModuleGraph graph)))
           else do
-            for_ @Stack errs (print . prettyNotice)
+            for_ @Stack errs (print . pretty @Notice)
             pure graph
         skipDeps graph m action = if all @Set.Set (flip Set.member (Map.keysSet (unModuleGraph graph))) (Map.keysSet (moduleImports m)) then action else pure graph
 

--- a/src/Path/REPL.hs
+++ b/src/Path/REPL.hs
@@ -126,8 +126,8 @@ script packageSources
   . runReader (ModuleName "(interpreter)")
   . fmap (either id id)
   . runError @()
-  $ runError loop >>= either print pure
-  where loop = (prompt "λ: " >>= parseCommand >>= maybe (pure ()) runCommand . join) `catchError` print >> loop
+  $ runError loop >>= either (print . pretty @Notice) pure
+  where loop = (prompt "λ: " >>= parseCommand >>= maybe (pure ()) runCommand . join) `catchError` (print . pretty @Notice) >> loop
         parseCommand str = do
           l <- askLine
           traverse (parseString (whole command) (linePos l)) str
@@ -156,16 +156,16 @@ script packageSources
               ordinal = brackets (pretty i <+> pretty "of" <+> pretty n)
               path    = parens (pretty (modulePath m))
           print (ordinal <+> pretty "Compiling" <+> pretty name <+> path)
-          (errs, res) <- runWriter @(Stack Doc) (runReader graph (elabModule m))
+          (errs, res) <- runWriter @(Stack Notice) (runReader graph (elabModule m))
           if Prelude.null errs then
             pure (ModuleGraph (Map.insert name (bindTEither Left res) (unModuleGraph graph)))
           else do
-            for_ errs print
+            for_ errs (print . pretty)
             pure graph
         skipDeps graph m action = if all @Set.Set (flip Set.member (Map.keysSet (unModuleGraph graph))) (Map.keysSet (moduleImports m)) then action else pure graph
 
 elaborate :: ( Carrier sig m
-             , Member (Error Doc) sig
+             , Member (Error Notice) sig
              , Member (State (ModuleGraph (Term (Problem :+: Core)) Void)) sig
              , Member (State (Set.Set ModuleName)) sig
              )

--- a/src/Path/Span.hs
+++ b/src/Path/Span.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveTraversable, FlexibleContexts #-}
 module Path.Span
 ( Span(..)
-, prettySpan
 , Pos(..)
 , advancePos
 , Excerpt(..)
@@ -14,7 +13,6 @@ module Path.Span
 ) where
 
 import Control.Effect.Reader
-import Text.PrettyPrint.ANSI.Leijen
 
 data Span = Span
   { spanStart :: {-# UNPACK #-} !Pos
@@ -24,12 +22,6 @@ data Span = Span
 
 instance Semigroup Span where
   Span s1 e1 <> Span s2 e2 = Span (min s1 s2) (max e1 e2)
-
-prettySpan :: Span -> Doc
-prettySpan (Span start end)
-  | start == end                 = green (pretty '^')
-  | posLine start == posLine end = green (pretty (replicate (posColumn end - posColumn start) '~'))
-  | otherwise                    = green (pretty "^…")
 
 
 data Pos = Pos

--- a/src/Path/Span.hs
+++ b/src/Path/Span.hs
@@ -25,9 +25,6 @@ data Span = Span
 instance Semigroup Span where
   Span s1 e1 <> Span s2 e2 = Span (min s1 s2) (max e1 e2)
 
-instance Pretty Span where
-  pretty = prettySpan
-
 prettySpan :: Span -> Doc
 prettySpan (Span start end)
   | start == end                 = green (pretty '^')

--- a/src/Path/Span.hs
+++ b/src/Path/Span.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveTraversable, FlexibleContexts #-}
 module Path.Span
 ( Span(..)
+, prettySpan
 , Pos(..)
 , advancePos
 , Excerpt(..)

--- a/src/Path/Span.hs
+++ b/src/Path/Span.hs
@@ -25,10 +25,13 @@ instance Semigroup Span where
   Span s1 e1 <> Span s2 e2 = Span (min s1 s2) (max e1 e2)
 
 instance Pretty Span where
-  pretty (Span start end)
-    | start == end                 = green (pretty '^')
-    | posLine start == posLine end = green (pretty (replicate (posColumn end - posColumn start) '~'))
-    | otherwise                    = green (pretty "^…")
+  pretty = prettySpan
+
+prettySpan :: Span -> Doc
+prettySpan (Span start end)
+  | start == end                 = green (pretty '^')
+  | posLine start == posLine end = green (pretty (replicate (posColumn end - posColumn start) '~'))
+  | otherwise                    = green (pretty "^…")
 
 
 data Pos = Pos

--- a/src/Path/Term.hs
+++ b/src/Path/Term.hs
@@ -61,5 +61,5 @@ prettyTermInContext
 prettyTermInContext alg = go
   where go :: forall n . Vec n Doc -> Term sig (Var (Fin n) a) -> Prec
         go ctx = \case
-          Var v -> atom (var (pretty . (ctx !)) pretty v)
+          Var v -> atom (var (ctx !) pretty v)
           Term t -> alg go ctx t


### PR DESCRIPTION
This PR:

- Replaces `ansi-wl-pprint` with `prettyprinter` & `prettyprinter-ansi-terminal`.
- Defines a `Doc` newtype & `Pretty` typeclass specialized to `Doc AnsiStyle`.
- Moves `Level` & `Notice` into `Path.Error`.
- Uses `Notice` instead of `Doc` as the error type.